### PR TITLE
修复简易合成终端被法术书破坏时引起的服务端崩溃

### DIFF
--- a/src/main/java/com/gtocore/integration/ae/SimpleCraftingTerminal.java
+++ b/src/main/java/com/gtocore/integration/ae/SimpleCraftingTerminal.java
@@ -7,8 +7,10 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.ComponentContents;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
 
 import appeng.api.behaviors.ExternalStorageStrategy;
@@ -43,6 +45,7 @@ import appeng.parts.PartModel;
 import appeng.parts.automation.StackWorldBehaviors;
 import appeng.parts.reporting.AbstractTerminalPart;
 import appeng.util.inv.AppEngInternalInventory;
+import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
@@ -75,6 +78,18 @@ public class SimpleCraftingTerminal extends AbstractTerminalPart
     @Override
     public boolean isActive() {
         return true;
+    }
+
+    @Override
+    public boolean onPartActivate(Player player, InteractionHand hand, Vec3 pos) {
+        if (isArsSpellBook(player.getMainHandItem()) || isArsSpellBook(player.getOffhandItem())) return false;
+        return super.onPartActivate(player, hand, pos);
+    }
+
+    private boolean isArsSpellBook(ItemStack itemStack) {
+        if (itemStack == null) return false;
+        String id = itemStack.getItem().getDescriptionId();
+        return id.contains("ars_nouveau") && id.contains("spell_book");
     }
 
     @Override


### PR DESCRIPTION
## 内容
修复了简易合成终端被法术书破坏时引起的服务端崩溃
## 崩溃细节
当使用Ars Nauveau的法术书破坏简易合成终端时，会使得打开的终端界面因为终端被破坏后仍然执行broadcastChange导致获取不到Grid，从而引起AE内部抛出的Grid错误。

https://github.com/user-attachments/assets/a14c33f7-eb22-4c79-8f64-cad15c0b1553


## 修复细节
测试发现当破坏对象为AE合成终端时，其被破坏后不会再broadcastChange。
所以理论上应阻止简易合成终端的Menu继续执行玩家tick，但我没找到对应的方法，因此换用了更为妥协直接的方法来禁止使用法术书时与终端交互。
