### PR TITLE
ph中和水 -> pH中和水

### DIFF
--- a/src/generated/resources/assets/gtocore/lang/zh_cn.json
+++ b/src/generated/resources/assets/gtocore/lang/zh_cn.json
@@ -4459,7 +4459,7 @@
   "material.gtocore.perditio_crystal": "混沌魔晶",
   "material.gtocore.perfluorobenzene": "全氟苯",
   "material.gtocore.periodicium": "錭錤錶",
-  "material.gtocore.ph_neutral_water": "ph中和水",
+  "material.gtocore.ph_neutral_water": "pH中和水",
   "material.gtocore.phenolic_resin": "酚醛树脂",
   "material.gtocore.phenylenedioxydiacetic_acid": "亚苯基二氧二乙酸",
   "material.gtocore.phenylpentanoic_acid": "苯基戊酸",


### PR DESCRIPTION
是否存在科学术语不严谨的问题？还是这条字符串是有意为之？