### PR TITLE
修复超维度熔炼在超级热容线圈时不能正常工作

### DIFF
--- a/src/main/java/com/gtocore/common/machine/multiblock/electric/smelter/DimensionallyTranscendentPlasmaForgeMachine.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/electric/smelter/DimensionallyTranscendentPlasmaForgeMachine.java
@@ -26,13 +26,14 @@ public final class DimensionallyTranscendentPlasmaForgeMachine extends CoilMulti
     @Override
     protected boolean beforeWorking(@Nullable Recipe recipe) {
         if (recipe == null) return false;
-        if (getCoilType() == CoilType.URUIUM) {
-            if (getRecipeType() != GTORecipeTypes.STELLAR_FORGE_RECIPES) {
-                return false;
-            } else if (recipe.data.getInt("ebf_temp") > 32000) {
+        if (getRecipeType() == GTORecipeTypes.STELLAR_FORGE_RECIPES) {
+            if (getCoilType() != CoilType.URUIUM) {
                 return false;
             }
-        } else if (recipe.data.getInt("ebf_temp") > getTemperature()) {
+            if (recipe.data.getInt("ebf_temp") > 32000) {
+                return false;
+            }
+        }else if (recipe.data.getInt("ebf_temp") > getTemperature()) {
             return false;
         }
         return super.beforeWorking(recipe);


### PR DESCRIPTION
从 超级热容线圈只能运行恒星锻炉
改成 恒星锻炉只能在超级热容线圈运行