### PR TITLE
修复鸿蒙之眼的基础运行时间

### DIFF
--- a/src/main/java/com/gtocore/common/machine/multiblock/noenergy/HarmonyMachine.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/noenergy/HarmonyMachine.java
@@ -107,7 +107,7 @@ public final class HarmonyMachine extends NoEnergyMultiblockMachine implements I
                         tier++;
                     }
                 }
-                recipe.duration = (recipe.duration << 2) / (1 << (oc));
+                recipe.duration = recipe.duration >> (oc - 1);
                 return recipe;
             }
         }


### PR DESCRIPTION
鸿蒙之眼 1号电路的运行时间应当和配方界面显示的一致