### PR TITLE
修复鸿蒙之眼的超频功率

### DIFF
--- a/src/main/java/com/gtocore/common/machine/multiblock/noenergy/HarmonyMachine.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/noenergy/HarmonyMachine.java
@@ -82,7 +82,7 @@ public final class HarmonyMachine extends NoEnergyMultiblockMachine implements I
     }
 
     private long getStartupEnergy() {
-        return oc == 0 ? 0 : (5277655810867200L * (1L << (4 * oc - 1)));
+        return oc == 0 ? 0 : (5277655810867200L * (1L << (3 * oc - 1)));
     }
 
     @Override


### PR DESCRIPTION
原来功率是32倍增长，改成修复为于描述相同的16倍
https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/613
还有 鸿蒙之眼的能耗计算有数值溢出 我无法修复