### PR TITLE
修复进阶无尽流体钻机无法升温

### DIFF
--- a/src/main/java/com/gtocore/common/machine/multiblock/electric/voidseries/AdvancedInfiniteDrillMachine.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/electric/voidseries/AdvancedInfiniteDrillMachine.java
@@ -67,25 +67,34 @@ public final class AdvancedInfiniteDrillMachine extends StorageMultiblockMachine
     private void heatUpdate() {
         if (getOffsetTimer() % 5 != 0) return;
         heatSubs.updateSubscription();
-        if (!getRecipeLogic().isWorking()) currentHeat = Math.max(300, currentHeat - 1);
-        if (isEmpty()) return;
-        int heat = 0;
-        if (getRecipeLogic().isWorking()) {
-            if (process <= 0) {
-                heat += (int) Math.floor(Math.abs(currentHeat - RUNNING_HEAT) / 2000.0);
-            }
+
+        boolean isWorking = getRecipeLogic().isWorking();
+        boolean playerWantsToHeat = !isEmpty() && inputBlast();
+
+        if (playerWantsToHeat && currentHeat < MAX_HEAT) {
+            currentHeat++;
+        }
+
+        if (isWorking && process <= 0) {
+            currentHeat += (int) Math.floor(Math.abs(currentHeat - RUNNING_HEAT) / 2000.0);
+        }
+
+        if (isWorking) {
             if (inputFluid(DISTILLED_WATER)) {
-                heat--;
+                currentHeat--;
             } else if (inputFluid(OXYGEN)) {
-                heat -= 2;
+                currentHeat -= 2;
             } else if (inputFluid(HELIUM)) {
-                heat -= 4;
+                currentHeat -= 4;
             }
         }
-        if (inputBlast()) {
-            heat++;
+
+        if (!isWorking && !playerWantsToHeat) {
+            currentHeat = Math.max(300, currentHeat - 1);
         }
-        currentHeat = Math.max(4, heat + currentHeat);
+
+        currentHeat = Math.max(4, currentHeat);
+
         if (currentHeat > MAX_HEAT) {
             process++;
             if (process >= 200) {

--- a/src/main/java/com/gtocore/common/machine/trait/AdvancedInfiniteDrillLogic.java
+++ b/src/main/java/com/gtocore/common/machine/trait/AdvancedInfiniteDrillLogic.java
@@ -66,6 +66,8 @@ public final class AdvancedInfiniteDrillLogic extends RecipeLogic implements IEn
         if (!veinFluids.isEmpty()) {
             var recipe = gtolib$getRecipeBuilder().duration(MAX_PROGRESS).EUt(20000).outputFluids(veinFluids.object2IntEntrySet().stream().map(entry -> new FluidStack(entry.getKey(), entry.getIntValue())).toArray(FluidStack[]::new)).buildRawRecipe();
             recipe.modifier(new ContentModifier(getParallel(), efficiency(getMachine().getRate() * 500)), true);
+            recipe.manat = 0L;
+            recipe.cwut = 0L;
             if (RecipeRunner.matchRecipe(machine, recipe) && RecipeRunner.matchTickRecipe(machine, recipe)) {
                 return recipe;
             }


### PR DESCRIPTION
顺序：主动升温（不超过上限，不造成损坏）工作升温（超过上限，造成损坏）主动冷却（不低于4k）被动冷却（空闲时 不低于300k） 临时去除魔力消耗，算力消耗
配方计算待重构（超频逻辑，无钻头时可以运行，软锤无法“结束后暂停”）

https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/677