### PR TITLE
fix: 修复维护仓损坏概率与配方时间正相关的错误逻辑

### DIFF
--- a/src/main/java/com/gtocore/mixin/gtm/machine/MaintenanceHatchPartMachineMixin.java
+++ b/src/main/java/com/gtocore/mixin/gtm/machine/MaintenanceHatchPartMachineMixin.java
@@ -60,7 +60,7 @@ public abstract class MaintenanceHatchPartMachineMixin extends WorkableTieredPar
     public void calculateMaintenance(IMaintenanceMachine maintenanceMachine, int duration) {
         if (maintenanceMachine.isFullAuto()) return;
         var pa = getController().getParts().length;
-        timeActive = MathUtil.saturatedCast((long) (timeActive + (duration * getDurationMultiplier() * GTOCore.difficulty * pa)));
+        timeActive = MathUtil.saturatedCast((long) (timeActive + (duration * getTimeMultiplier() * GTOCore.difficulty * pa)));
         var value = ((float) timeActive / MINIMUM_MAINTENANCE_TIME) - 0.7;
         if (GTValues.RNG.nextFloat() <= value && !GTOCore.isEasy()) {
             timeActive = 0;


### PR DESCRIPTION
getDurationMultiplier 是给配方时间的 multiplier，getTimeMultiplier 是对维护仓损坏概率的 multiplier，原版 GTM 就是这么用的，GTOCore mixin 的时候都用了 duration multiplier 没用到 time multiplier，导致实际上的效果是，可配置维护仓配置的配方运行耗时越短，维护仓损坏概率反倒更低了