### PR TITLE
feat: 在服务器重启后加载 opac 强加载区块

### DIFF
--- a/src/main/java/com/gtocore/mixin/opac/CommonEventsMixin.java
+++ b/src/main/java/com/gtocore/mixin/opac/CommonEventsMixin.java
@@ -1,0 +1,42 @@
+package io.github.tonycrane.tcpatch.mixin.opac;
+
+import net.minecraft.server.MinecraftServer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import xaero.pac.common.claims.player.IPlayerChunkClaim;
+import xaero.pac.common.claims.player.IPlayerClaimPosList;
+import xaero.pac.common.claims.player.IPlayerDimensionClaims;
+import xaero.pac.common.event.CommonEvents;
+import xaero.pac.common.parties.party.IPartyPlayerInfo;
+import xaero.pac.common.parties.party.ally.IPartyAlly;
+import xaero.pac.common.parties.party.member.IPartyMember;
+import xaero.pac.common.server.IOpenPACMinecraftServer;
+import xaero.pac.common.server.IServerData;
+import xaero.pac.common.server.IServerDataAPI;
+import xaero.pac.common.server.claims.IServerClaimsManager;
+import xaero.pac.common.server.claims.IServerDimensionClaimsManager;
+import xaero.pac.common.server.claims.IServerRegionClaims;
+import xaero.pac.common.server.claims.player.IServerPlayerClaimInfo;
+import xaero.pac.common.server.parties.party.IServerParty;
+import xaero.pac.common.server.player.config.IPlayerConfigManager;
+
+@Mixin(value = CommonEvents.class, remap = false)
+public abstract class CommonEventsMixin {
+
+    @Inject(method = "onServerStarting", at = @At("TAIL"))
+    private void tcpatch$restoreOfflineForceloads(MinecraftServer server, CallbackInfo ci) {
+        IServerDataAPI serverDataApi = ((IOpenPACMinecraftServer) server).getXaero_OPAC_ServerData();
+        if (serverDataApi == null) {
+            return;
+        }
+        @SuppressWarnings("unchecked")
+        IServerData<IServerClaimsManager<IPlayerChunkClaim, IServerPlayerClaimInfo<IPlayerDimensionClaims<IPlayerClaimPosList>>, IServerDimensionClaimsManager<IServerRegionClaims>>, IServerParty<IPartyMember, IPartyPlayerInfo, IPartyAlly>> serverData = (IServerData<IServerClaimsManager<IPlayerChunkClaim, IServerPlayerClaimInfo<IPlayerDimensionClaims<IPlayerClaimPosList>>, IServerDimensionClaimsManager<IServerRegionClaims>>, IServerParty<IPartyMember, IPartyPlayerInfo, IPartyAlly>>) serverDataApi;
+        IPlayerConfigManager playerConfigManager = (IPlayerConfigManager) serverDataApi.getPlayerConfigs();
+        serverData.getServerClaimsManager().getTypedPlayerInfoStream().forEach(playerInfo -> {
+            serverData.getForceLoadManager().updateTicketsFor(playerConfigManager, playerInfo.getPlayerId(), true);
+        });
+    }
+}

--- a/src/main/resources/gtocore.mixins.json
+++ b/src/main/resources/gtocore.mixins.json
@@ -221,6 +221,7 @@
     "merequester.RequesterBlockEntityMixin",
     "merequester.RequestMixin",
     "opac.ChunkProtectionMixin",
+    "opac.CommonEventsMixin",
     "patchouli.BookCategoryMixin",
     "patchouli.BookEntryMixin",
     "patchouli.BookMixin",


### PR DESCRIPTION
opac 只会在玩家上线/下线的时候更新强加载 tickets，所以服务器上比较不方便，即使设置了玩家离线强加载，也只有认领区块的玩家上线以后才可以强加载认领的区块。以及 server-claim-mode 认领的服务器区块因为伪玩家 uuid 0 不会上线导致重启后没有强加载服务器区块。

这个 PR 加了个 opac 的 mixin，在 CommonEvents 里服务器启动后刷新所有已经记录过的玩家的 tickets，即使服务器重启过也可以继续强加载设定过的区块无需玩家上线。