### PR TITLE
fix: 修复吞吐量监控器变化量不正常的问题

### DIFF
--- a/src/main/java/com/gtocore/common/machine/monitor/MonitorAEThroughput.java
+++ b/src/main/java/com/gtocore/common/machine/monitor/MonitorAEThroughput.java
@@ -13,15 +13,16 @@ import com.gregtechceu.gtceu.common.machine.multiblock.electric.PowerSubstationM
 import net.minecraft.ChatFormatting;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
 import appeng.api.stacks.AEKey;
+import appeng.api.stacks.AmountFormat;
 
 import com.google.common.collect.ImmutableList;
 import com.hepdd.gtmthings.api.misc.EnergyStat;
-import com.hepdd.gtmthings.utils.FormatUtil;
 import com.lowdragmc.lowdraglib.gui.widget.ComponentPanelWidget;
 import com.lowdragmc.lowdraglib.gui.widget.Widget;
 import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
@@ -30,13 +31,19 @@ import com.lowdragmc.lowdraglib.syncdata.annotation.Persisted;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
 public class MonitorAEThroughput extends AbstractAEInfoMonitor {
+
+    private static final BigDecimal DISPLAY_SCALE = BigDecimal.valueOf(100);
+    private static final DecimalFormat THROUGHPUT_FORMAT = new DecimalFormat("0.##");
 
     @DescSynced
     private CompoundTag displayingEntry = new CompoundTag();
@@ -71,7 +78,11 @@ public class MonitorAEThroughput extends AbstractAEInfoMonitor {
     @Override
     public void syncInfoFromServer() {
         var time = (int) Objects.requireNonNull(getLevel(), "Not on the server side").getGameTime();
-        if (time - lastUpdateTime < 40) return; // Update every 2 seconds
+        if (lastUpdateTime == 0) {
+            lastUpdateTime = time;
+        }
+        var elapsedTicks = time - lastUpdateTime;
+        if (elapsedTicks < 40) return; // Update every 2 seconds
         lastUpdateTime = time;
         var grid = nodeHolder.getMainNode().getGrid();
         if (grid == null || !isOnline()) {
@@ -88,22 +99,32 @@ public class MonitorAEThroughput extends AbstractAEInfoMonitor {
             }
             hasConfig = true;
             long amount = IExpandedStorageService.of(grid.getStorageService()).getLazyKeyCounter().get(current);
-            var change = amount - lastAmount[i];
             if (stats[i] == null) {
-                stats[i] = new EnergyStat(lastUpdateTime);
+                stats[i] = new EnergyStat(time);
+                stats[i].update(BigInteger.ZERO, time);
+                lastAmount[i] = amount;
+                currentAmount[i] = amount;
+                lastMinuteStat[i] = 0;
+                lastHourStat[i] = 0;
+                lastDayStat[i] = 0;
+                nowStat[i] = 0;
+                displayingEntry.put(String.valueOf(i), current.toTagGeneric());
+                continue;
             }
-            if (change != 0) {
-                // No zero update otherwise ArithmeticException will be thrown
-                stats[i].update(BigInteger.valueOf(change), lastUpdateTime);
+            var change = amount - lastAmount[i];
+            stats[i].update(BigInteger.valueOf(change), time);
+            for (int tick = 20; tick <= elapsedTicks; tick += 20) {
+                stats[i].tick();
             }
-            lastAmount[i] = currentAmount[i];
+            lastAmount[i] = amount;
             currentAmount[i] = amount;
 
-            lastMinuteStat[i] = stats[i].minute.getAvgByTick().longValue();
-            lastHourStat[i] = stats[i].hour.getAvgByTick().longValue();
-            lastDayStat[i] = stats[i].day.getAvgByTick().longValue();
+            lastMinuteStat[i] = scaleStat(stats[i].minute.getAvgByTick());
+            lastHourStat[i] = scaleStat(stats[i].hour.getAvgByTick());
+            lastDayStat[i] = scaleStat(stats[i].day.getAvgByTick());
 
-            nowStat[i] = change;
+            nowStat[i] = elapsedTicks > 0 ? scaleStat(BigDecimal.valueOf(change)
+                    .divide(BigDecimal.valueOf(elapsedTicks), 2, RoundingMode.HALF_UP)) : 0;
             // displayingName[i] = current.getDisplayName();
             displayingEntry.put(String.valueOf(i), current.toTagGeneric());
         }
@@ -140,51 +161,57 @@ public class MonitorAEThroughput extends AbstractAEInfoMonitor {
         if (state == State.NORMAL) {
             for (int i = 0; i < 2; i++) {
                 if (displayingEntry.contains(String.valueOf(i))) {
-                    final var unit = i == 0 ? 80 : 80000; // Items are in units, fluids are in mB
                     var atomI = new AtomicInteger(i == 0 ? 0 : 6);
-                    final BiFunction<Long, ChatFormatting, Component> formatter = getAmountFormatter(i, unit);
                     var itemId = ID_MAP.get(atomI.getAndIncrement()).id();
                     var itemKey = AEKey.fromTagGeneric(displayingEntry.getCompound(String.valueOf(i)));
                     if (itemKey != null) {
+                        final BiFunction<Long, ChatFormatting, MutableComponent> formatter = getAmountFormatter(itemKey);
                         infoList.addIfAbsent(
                                 itemId,
                                 Component.translatable("gtocore.machine.monitor.ae.status." + i,
                                         itemKey.getDisplayName().copy().withStyle(ChatFormatting.AQUA)).getVisualOrderText());
-
-                    }
-
-                    infoList.addIfAbsent(
-                            ID_MAP.get(atomI.getAndIncrement()).id(),
-                            Component.translatable("gtocore.machine.monitor.ae.amount",
-                                    Component.literal(FormatUtil.formatNumber(currentAmount[i] / unit * 80))
-                                            .withStyle(ChatFormatting.GOLD)
-                                            .append(Component.literal(i == 0 ? "" : "B").withStyle(ChatFormatting.GRAY))
-                                            .append(Component.literal("(").withStyle(ChatFormatting.WHITE)
-                                                    .append(formatter.apply(nowStat[i], ChatFormatting.DARK_PURPLE))
-                                                    .append(Component.literal("/t").withStyle(ChatFormatting.GRAY))
-                                                    .append(")").withStyle(ChatFormatting.WHITE)))
-                                    .getVisualOrderText());
-                    infoList.addIfAbsent(
-                            DisplayRegistry.AE_STAT_TITLE.id(),
-                            Component.translatable("gtocore.machine.monitor.ae.stat.title").getVisualOrderText());
-                    infoList.addIfAbsent(
-                            ID_MAP.get(atomI.getAndIncrement()).id(),
-                            Component.translatable("gtocore.machine.monitor.ae.stat.minute",
-                                    formatter.apply(lastMinuteStat[i], ChatFormatting.DARK_AQUA)).getVisualOrderText());
-                    infoList.addIfAbsent(
-                            ID_MAP.get(atomI.getAndIncrement()).id(),
-                            Component.translatable("gtocore.machine.monitor.ae.stat.hour",
-                                    formatter.apply(lastHourStat[i], ChatFormatting.YELLOW)).getVisualOrderText());
-                    infoList.addIfAbsent(
-                            ID_MAP.get(atomI.getAndIncrement()).id(),
-                            Component.translatable("gtocore.machine.monitor.ae.stat.day",
-                                    formatter.apply(lastDayStat[i], ChatFormatting.DARK_GREEN)).getVisualOrderText());
-                    if (nowStat[i] < 0) {
-                        var absSec = Math.abs(nowStat[i]) * 20;
                         infoList.addIfAbsent(
                                 ID_MAP.get(atomI.getAndIncrement()).id(),
-                                Component.translatable("gtocore.machine.monitor.ae.stat.remaining_time",
-                                        PowerSubstationMachine.getTimeToFillDrainText(BigInteger.valueOf(currentAmount[i] / absSec)).withStyle(ChatFormatting.GRAY)).getVisualOrderText());
+                                Component.translatable("gtocore.machine.monitor.ae.amount",
+                                        Component.literal(itemKey.formatAmount(currentAmount[i], AmountFormat.SLOT))
+                                                .withStyle(ChatFormatting.GOLD)
+                                                .append(Component.literal("(").withStyle(ChatFormatting.WHITE)
+                                                        .append(formatter.apply(nowStat[i], ChatFormatting.DARK_PURPLE))
+                                                        .append(Component.literal("/t").withStyle(ChatFormatting.GRAY))
+                                                        .append(")").withStyle(ChatFormatting.WHITE)))
+                                        .getVisualOrderText());
+                        infoList.addIfAbsent(
+                                DisplayRegistry.AE_STAT_TITLE.id(),
+                                Component.translatable("gtocore.machine.monitor.ae.stat.title").getVisualOrderText());
+                        infoList.addIfAbsent(
+                                ID_MAP.get(atomI.getAndIncrement()).id(),
+                                Component.translatable("gtocore.machine.monitor.ae.stat.minute",
+                                        formatter.apply(lastMinuteStat[i], ChatFormatting.DARK_AQUA)
+                                                .append(Component.literal("/t").withStyle(ChatFormatting.GRAY)))
+                                        .getVisualOrderText());
+                        infoList.addIfAbsent(
+                                ID_MAP.get(atomI.getAndIncrement()).id(),
+                                Component.translatable("gtocore.machine.monitor.ae.stat.hour",
+                                        formatter.apply(lastHourStat[i], ChatFormatting.YELLOW)
+                                                .append(Component.literal("/t").withStyle(ChatFormatting.GRAY)))
+                                        .getVisualOrderText());
+                        infoList.addIfAbsent(
+                                ID_MAP.get(atomI.getAndIncrement()).id(),
+                                Component.translatable("gtocore.machine.monitor.ae.stat.day",
+                                        formatter.apply(lastDayStat[i], ChatFormatting.DARK_GREEN)
+                                                .append(Component.literal("/t").withStyle(ChatFormatting.GRAY)))
+                                        .getVisualOrderText());
+                        if (nowStat[i] < 0) {
+                            var absSec = Math.abs(nowStat[i]) / DISPLAY_SCALE.doubleValue() * 20;
+                            infoList.addIfAbsent(
+                                    ID_MAP.get(atomI.getAndIncrement()).id(),
+                                    Component.translatable("gtocore.machine.monitor.ae.stat.remaining_time",
+                                            PowerSubstationMachine.getTimeToFillDrainText(BigDecimal.valueOf(currentAmount[i])
+                                                    .divide(BigDecimal.valueOf(absSec), 0, RoundingMode.CEILING)
+                                                    .toBigInteger())
+                                                    .withStyle(ChatFormatting.GRAY))
+                                            .getVisualOrderText());
+                        }
                     }
                 }
             }
@@ -192,15 +219,22 @@ public class MonitorAEThroughput extends AbstractAEInfoMonitor {
         return infoList;
     }
 
-    private @NotNull BiFunction<Long, ChatFormatting, Component> getAmountFormatter(int i, int unit) {
+    private @NotNull BiFunction<Long, ChatFormatting, MutableComponent> getAmountFormatter(AEKey key) {
         return (num, color) -> {
-            var sign = nowStat[i] >= 0 ? "+" : "-";
-            if (num % unit != 0) sign += "~";
-            return Component.literal(sign).withStyle(color)
-                    .append(Component.literal(FormatUtil.formatNumber(Math.abs(num) / unit))
-                            .withStyle(color))
-                    .append(Component.literal(i == 0 ? "" : "B").withStyle(ChatFormatting.GRAY));
+            double amount = num / DISPLAY_SCALE.doubleValue();
+            var prefix = amount >= 0 ? "+" : "-";
+            double displayAmount = Math.abs(amount) / key.getAmountPerUnit();
+            var component = Component.literal(prefix + THROUGHPUT_FORMAT.format(displayAmount)).withStyle(color);
+            var unit = key.getUnitSymbol();
+            if (unit != null) {
+                component.append(Component.literal(unit).withStyle(ChatFormatting.GRAY));
+            }
+            return component;
         };
+    }
+
+    private static long scaleStat(BigDecimal value) {
+        return value.multiply(DISPLAY_SCALE).setScale(0, RoundingMode.HALF_UP).longValue();
     }
 
     @Override
@@ -218,6 +252,12 @@ public class MonitorAEThroughput extends AbstractAEInfoMonitor {
 
     private void onFilterChanged(int slot) {
         stats[slot] = null;
+        lastAmount[slot] = 0;
+        currentAmount[slot] = 0;
+        lastMinuteStat[slot] = 0;
+        lastHourStat[slot] = 0;
+        lastDayStat[slot] = 0;
+        nowStat[slot] = 0;
     }
 
     private class AEItem extends ExportOnlyAEItemList implements CurrentGettable {


### PR DESCRIPTION
这部分用的 GTMT 的 EnergyStat 来统计，但写的不对，EnergyStat 在 GTMT 里注册了每 1s 跑一次 .tick()，监控器的代码里完全没跑过 tick，这样 update 更新是没用的。而且还有一个没看懂的 / 80 或 / 80000 的逻辑，导致除下来的显示四舍五入基本都是 ~0。

这个 PR 在 syncInfoFromServer 的时候补充 .tick() 的调用，然后用了 AE 的接口来显示容量和单位

## Before

<img width="1063" height="590" alt="65cecdf62cf95594aba2ac1850609228" src="https://github.com/user-attachments/assets/8b055695-2b37-4e7a-985b-70c2dc45f451" />

## After

<img width="731" height="733" alt="a2167b5f6adc60235959a270b5766e4c" src="https://github.com/user-attachments/assets/427d2794-42cf-484f-9ecc-c982b83c61ae" />
