### PR TITLE
fix: 修复装配矩阵一个样板核心装满可能会导致在发送列表被移除的问题

### DIFF
--- a/src/main/java/com/gtocore/mixin/ae2/menu/PatternEncodingTermMenuMixin.java
+++ b/src/main/java/com/gtocore/mixin/ae2/menu/PatternEncodingTermMenuMixin.java
@@ -256,9 +256,10 @@ public abstract class PatternEncodingTermMenuMixin extends MEStorageMenu impleme
 
         machines.removeIf(container -> {
             var patternInv = container.getTerminalPatternInventory();
+            var simulate = patternInv.simulateAdd(stack);
 
             if (!container.isVisibleInTerminal() ||
-                    patternInv.simulateAdd(stack) == stack)
+                    ItemStack.isSameItemSameTags(simulate, stack) && simulate.getCount() == stack.getCount())
                 return true;
             if (patternInv instanceof AppEngInternalInventory aeInv &&
                     aeInv.getHost() instanceof TileAssemblerMatrixPattern matrixPattern) {


### PR DESCRIPTION
直接 == 比较的应该是引用，simulateAdd 会返回 stack.copy() 导致这个判断应该是 true 但实际是 false

如果装配矩阵一个核心是满的，它应该在这里被移除，但如果没被移除，它可能会作为 cluster 的代表，然后因为它确实放不下了导致在发送目的地的排序里面被放到后面了，即使其他核心可以放得下