### PR TITLE
Fix sensor equal threshold redstone output

### DIFF
--- a/src/main/java/com/gtocore/common/machine/multiblock/part/SensorPartMachine.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/part/SensorPartMachine.java
@@ -68,13 +68,19 @@ public final class SensorPartMachine extends MultiblockPartMachine {
     }
 
     private static int computeRedstoneBetweenValues(float value, float maxValue, float minValue, boolean isInverted) {
-        if (value < minValue) {
+        float lower = Math.min(minValue, maxValue);
+        float upper = Math.max(minValue, maxValue);
+        if (value < lower) {
             return isInverted ? 15 : 0;
         }
-        if (value > maxValue) {
+        if (value > upper) {
             return isInverted ? 15 : 0;
         }
-        return (int) Math.ceil(15 * (isInverted ? (maxValue - value) : (value - minValue)) / (maxValue - minValue));
+        if (Float.compare(lower, upper) == 0) {
+            return isInverted ? 0 : 15;
+        }
+        float normalized = isInverted ? (upper - value) / (upper - lower) : (value - lower) / (upper - lower);
+        return Math.max(0, Math.min(15, (int) Math.ceil(15 * normalized)));
     }
 
     @Override


### PR DESCRIPTION
## Summary
- handle sensor min/max values in either order
- define deterministic output for equal thresholds
- clamp computed redstone output to 0..15

## Verification
- temporary sensor formula regression covering equal thresholds, inversion, reversed min/max, and normal range
- git diff --check
- .\\gradlew.bat compileJava --no-daemon --console=plain