### PR TITLE
Fix CWU duration semantics for research data recipes

### DIFF
--- a/src/main/java/com/gtocore/data/recipe/builder/research/DataAnalysisRecipeBuilder.java
+++ b/src/main/java/com/gtocore/data/recipe/builder/research/DataAnalysisRecipeBuilder.java
@@ -99,7 +99,7 @@ public final class DataAnalysisRecipeBuilder {
                 .chancedOutput(ErrorDataCrystalList.get(crystalTire), errorChance, 0)
                 .EUt(eut)
                 .CWUt(cwut)
-                .totalCWU(totalCWU)
+                .duration(ResearchRecipeDuration.fromTotalCWU(totalCWU, cwut))
                 .save();
     }
 }

--- a/src/main/java/com/gtocore/data/recipe/builder/research/DataCrystalConstruction.java
+++ b/src/main/java/com/gtocore/data/recipe/builder/research/DataCrystalConstruction.java
@@ -117,7 +117,7 @@ public final class DataCrystalConstruction {
             builder.outputItems(dataStack)
                     .EUt(eut)
                     .CWUt(cwut)
-                    .totalCWU(totalCWU)
+                    .duration(ResearchRecipeDuration.fromTotalCWU(totalCWU, cwut))
                     .save();
         }
     }

--- a/src/main/java/com/gtocore/data/recipe/builder/research/DataIntegrationRecipeBuilder.java
+++ b/src/main/java/com/gtocore/data/recipe/builder/research/DataIntegrationRecipeBuilder.java
@@ -98,7 +98,7 @@ public final class DataIntegrationRecipeBuilder {
                 .chancedOutput(ErrorDataCrystalList.get(crystalTire), normalizedError, 0)
                 .EUt(eut)
                 .CWUt(cwut)
-                .totalCWU(totalCWU)
+                .duration(ResearchRecipeDuration.fromTotalCWU(totalCWU, cwut))
                 .save();
     }
 }

--- a/src/main/java/com/gtocore/data/recipe/builder/research/RecipesDataGenerateRecipeBuilder.java
+++ b/src/main/java/com/gtocore/data/recipe/builder/research/RecipesDataGenerateRecipeBuilder.java
@@ -116,7 +116,7 @@ public final class RecipesDataGenerateRecipeBuilder {
                 .chancedOutput(dataStack, chance, 0)
                 .EUt(eut)
                 .CWUt(cwut)
-                .totalCWU(totalCWU)
+                .duration(ResearchRecipeDuration.fromTotalCWU(totalCWU, cwut))
                 .save();
     }
 }

--- a/src/main/java/com/gtocore/data/recipe/builder/research/ResearchRecipeDuration.java
+++ b/src/main/java/com/gtocore/data/recipe/builder/research/ResearchRecipeDuration.java
@@ -1,0 +1,12 @@
+package com.gtocore.data.recipe.builder.research;
+
+final class ResearchRecipeDuration {
+
+    private ResearchRecipeDuration() {}
+
+    static int fromTotalCWU(int totalCWU, int cwut) {
+        if (cwut <= 0) throw new IllegalStateException("CWU/t must be greater than zero");
+        if (totalCWU <= 0) throw new IllegalStateException("Total CWU must be greater than zero");
+        return Math.max(1, Math.ceilDiv(totalCWU, cwut));
+    }
+}

--- a/src/test/scripts/check_cwu_total_semantics.ps1
+++ b/src/test/scripts/check_cwu_total_semantics.ps1
@@ -1,0 +1,24 @@
+$ErrorActionPreference = 'Stop'
+
+$root = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
+$builderDir = Join-Path $root 'main/java/com/gtocore/data/recipe/builder/research'
+$ordinaryElectricBuilders = @(
+    'DataAnalysisRecipeBuilder.java',
+    'DataIntegrationRecipeBuilder.java',
+    'RecipesDataGenerateRecipeBuilder.java',
+    'DataCrystalConstruction.java'
+)
+
+$failures = @()
+foreach ($file in $ordinaryElectricBuilders) {
+    $path = Join-Path $builderDir $file
+    $text = Get-Content -Raw $path
+    if ($text -match '\.totalCWU\s*\(') {
+        $failures += "$file uses GTRecipeBuilder.totalCWU() for an ordinary electric recipe"
+    }
+}
+
+if ($failures.Count -gt 0) {
+    $failures | ForEach-Object { Write-Error $_ }
+    exit 1
+}


### PR DESCRIPTION
## Summary
- stop using `GTRecipeBuilder.totalCWU()` for GTO's ordinary electric research-data recipe builders
- convert total CWU into tick duration with `ceil(totalCWU / CWUt)` while keeping per-tick `CWUt` consumption
- add a small static regression script for these ordinary electric builders

## Verification
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File .\src\test\scripts\check_cwu_total_semantics.ps1`
- `.\gradlew.bat compileJava --no-daemon --console=plain`

## Notes
`GTRecipeBuilder.totalCWU()` marks `duration` as total CWU, which is appropriate for ResearchStation-style progression but incorrect for these ELECTRIC recipe types that run through ordinary recipe logic and consume CWU per tick.