### PR TITLE
Fix Dissolving Tank fluid input guard

### DIFF
--- a/src/main/java/com/gtocore/common/machine/multiblock/electric/DissolvingTankMachine.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/electric/DissolvingTankMachine.java
@@ -64,6 +64,9 @@ public final class DissolvingTankMachine extends ElectricMultiblockMachine imple
             return GTORecipeModifiers.UPGRADE_PARALLELIZABLE_OVERCLOCK.applyModifier(this, unit, recipe);
         }
         var fluidList = recipe.fluidInputs;
+        if (fluidList.size() < 2) {
+            return null;
+        }
         var fluidStack1 = fluidList.get(0);
         var fluidStack2 = fluidList.get(1);
         long[] a = unit.getFluidAmount(true, fluidStack1.inner.getFluid(), fluidStack2.inner.getFluid());

--- a/src/test/scripts/check_dissolving_tank_fluid_input_guard.ps1
+++ b/src/test/scripts/check_dissolving_tank_fluid_input_guard.ps1
@@ -1,0 +1,23 @@
+$ErrorActionPreference = 'Stop'
+
+$path = Join-Path $PSScriptRoot '../../main/java/com/gtocore/common/machine/multiblock/electric/DissolvingTankMachine.java'
+$source = Get-Content -Raw -Path $path
+
+$guardPattern = 'var fluidList = recipe\.fluidInputs;\s*if \(fluidList\.size\(\) < 2\) \{\s*return null;\s*\}'
+if ($source -notmatch $guardPattern) {
+    throw 'DissolvingTankMachine must guard recipes with fewer than two fluid inputs before reading get(0)/get(1).'
+}
+
+$guardIndex = $source.IndexOf('fluidList.size() < 2')
+$firstAccessIndex = $source.IndexOf('fluidList.get(0)')
+$secondAccessIndex = $source.IndexOf('fluidList.get(1)')
+
+if ($firstAccessIndex -lt 0 -or $secondAccessIndex -lt 0) {
+    throw 'DissolvingTankMachine fluid ratio logic must still read the first two fluid inputs after the guard.'
+}
+
+if ($guardIndex -lt 0 -or $guardIndex -gt $firstAccessIndex -or $guardIndex -gt $secondAccessIndex) {
+    throw 'DissolvingTankMachine fluid input guard must run before both indexed fluid input reads.'
+}
+
+Write-Host 'DissolvingTankMachine fluid input guard regression check passed.'


### PR DESCRIPTION
## 修复内容
- DissolvingTankMachine 在无子结构路径读取双流体比例前，先检查 `recipe.fluidInputs.size() < 2`。
- 少于两个流体输入时直接返回 `null`，避免配方匹配阶段 `get(0)` / `get(1)` 越界崩溃。
- 添加静态回归脚本，锁定保护必须在索引读取前执行。

## 验证
- 红灯：修复前 `powershell -NoProfile -ExecutionPolicy Bypass -File .\src\test\scripts\check_dissolving_tank_fluid_input_guard.ps1` 会失败，提示缺少 guard。
- 绿灯：修复后同一脚本通过。
- `git diff --check`
- `.\gradlew.bat compileJava --no-daemon --console=plain`