### PR TITLE
Refactor travel target render context lookup

### DIFF
--- a/scripts/regression/travel_render_cache.ps1
+++ b/scripts/regression/travel_render_cache.ps1
@@ -4,17 +4,25 @@ $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..')
 $sourcePath = Join-Path $repoRoot 'src\main\java\com\gtocore\eio_travel\client\RenderTravelTargets.java'
 $source = Get-Content -Raw $sourcePath
 
-$minecraftCalls = ([regex]::Matches($source, 'Minecraft\.getInstance\(\)')).Count
-if ($minecraftCalls -gt 1) {
-    throw "renderLevel should cache Minecraft.getInstance(); found $minecraftCalls calls."
+function Get-SingleMatch([string] $pattern, [string] $description) {
+    $matches = [regex]::Matches($source, $pattern)
+    if ($matches.Count -ne 1) {
+        throw "renderLevel should contain exactly one $description; found $($matches.Count)."
+    }
+    return $matches[0]
 }
 
-if ($source -cnotmatch 'PoseStack poseStack = event\.getPoseStack\(\);') {
-    throw 'renderLevel should cache the PoseStack outside the target loop.'
+function Assert-BeforeLoop([System.Text.RegularExpressions.Match] $match, [string] $description) {
+    if ($match.Index -gt $targetLoop.Index) {
+        throw "renderLevel should cache $description before the target loop."
+    }
 }
 
-if ($source -cnotmatch 'Vec3 projectedView = mainCamera\.getPosition\(\);') {
-    throw 'renderLevel should cache the camera position outside the target loop.'
-}
+$targetLoop = Get-SingleMatch 'for\s*\(\s*ITravelTarget\s+target\s*:\s*targets\s*\)\s*\{' 'target render loop'
+
+Assert-BeforeLoop (Get-SingleMatch 'Minecraft\.getInstance\(\)' 'Minecraft.getInstance() call') 'Minecraft.getInstance()'
+Assert-BeforeLoop (Get-SingleMatch 'PoseStack\s+poseStack\s*=\s*event\.getPoseStack\(\);' 'PoseStack cache') 'the PoseStack'
+Assert-BeforeLoop (Get-SingleMatch 'Camera\s+mainCamera\s*=\s*minecraft\.gameRenderer\.getMainCamera\(\);' 'main camera cache') 'the main camera'
+Assert-BeforeLoop (Get-SingleMatch 'Vec3\s+projectedView\s*=\s*mainCamera\.getPosition\(\);' 'camera position cache') 'the camera position'
 
 Write-Host 'RenderTravelTargets cache regression check passed.'

--- a/scripts/regression/travel_render_cache.ps1
+++ b/scripts/regression/travel_render_cache.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..')
+$sourcePath = Join-Path $repoRoot 'src\main\java\com\gtocore\eio_travel\client\RenderTravelTargets.java'
+$source = Get-Content -Raw $sourcePath
+
+$minecraftCalls = ([regex]::Matches($source, 'Minecraft\.getInstance\(\)')).Count
+if ($minecraftCalls -gt 1) {
+    throw "renderLevel should cache Minecraft.getInstance(); found $minecraftCalls calls."
+}
+
+if ($source -cnotmatch 'PoseStack poseStack = event\.getPoseStack\(\);') {
+    throw 'renderLevel should cache the PoseStack outside the target loop.'
+}
+
+if ($source -cnotmatch 'Vec3 projectedView = mainCamera\.getPosition\(\);') {
+    throw 'renderLevel should cache the camera position outside the target loop.'
+}
+
+Write-Host 'RenderTravelTargets cache regression check passed.'

--- a/src/main/java/com/gtocore/eio_travel/client/RenderTravelTargets.java
+++ b/src/main/java/com/gtocore/eio_travel/client/RenderTravelTargets.java
@@ -24,8 +24,9 @@ public class RenderTravelTargets {
 
     @SubscribeEvent
     public static void renderLevel(RenderLevelStageEvent event) {
-        ClientLevel level = Minecraft.getInstance().level;
-        LocalPlayer player = Minecraft.getInstance().player;
+        Minecraft minecraft = Minecraft.getInstance();
+        ClientLevel level = minecraft.level;
+        LocalPlayer player = minecraft.player;
         if (level == null || player == null || event.getStage() != RenderLevelStageEvent.Stage.AFTER_TRIPWIRE_BLOCKS) {
             return;
         }
@@ -35,10 +36,13 @@ public class RenderTravelTargets {
         }
 
         boolean itemTeleport = TravelHandler.canItemTeleport(player);
-        TravelSavedData data = TravelSavedData.getTravelData(Minecraft.getInstance().level);
+        TravelSavedData data = TravelSavedData.getTravelData(level);
         @Nullable
         ITravelTarget activeTarget = TravelHandler.getTeleportAnchorTarget(player).orElse(null);
         var targets = TravelUtils.filterTargets(player, data.getTravelTargets().stream()).toList();
+        PoseStack poseStack = event.getPoseStack();
+        Camera mainCamera = minecraft.gameRenderer.getMainCamera();
+        Vec3 projectedView = mainCamera.getPosition();
         for (ITravelTarget target : targets) {
             double range = itemTeleport ? target.getItem2BlockRange() : target.getBlock2BlockRange();
             double distanceSquared = target.getPos().distToCenterSqr(player.position());
@@ -46,10 +50,7 @@ public class RenderTravelTargets {
                 continue;
             }
 
-            PoseStack poseStack = event.getPoseStack();
             poseStack.pushPose();
-            Camera mainCamera = Minecraft.getInstance().gameRenderer.getMainCamera();
-            Vec3 projectedView = mainCamera.getPosition();
             poseStack.translate(-projectedView.x, -projectedView.y, -projectedView.z);
 
             boolean active = activeTarget == target;


### PR DESCRIPTION
## Summary
- cache Minecraft, PoseStack, camera, and camera position once per travel render pass
- keep per-target push/pop and render behavior unchanged
- add a regression script for the cached render context

## Test Plan
- powershell -ExecutionPolicy Bypass -File scripts/regression/travel_render_cache.ps1
- git diff --check
- ./gradlew.bat compileJava compileKotlin --no-daemon --console=plain