### PR TITLE
Filter travel targets in a single pass

### DIFF
--- a/scripts/regression/travel_filter_by_block_single_pass.ps1
+++ b/scripts/regression/travel_filter_by_block_single_pass.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = "Stop"
+
+$root = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$file = Join-Path $root "src\main\java\com\gtocore\eio_travel\logic\TravelUtils.java"
+$text = Get-Content -Raw -LiteralPath $file
+
+if ($text -match "targets\.toList\(\)") {
+    throw "filterByBlock should not materialize all travel targets"
+}
+if ($text -match "existingBlockTypes") {
+    throw "filterByBlock should avoid the old duplicate block-type scan"
+}
+if ($text -notmatch "return targets\.filter") {
+    throw "filterByBlock should filter the target stream directly"
+}
+if ($text -notmatch "/\*\*[\s\S]*filterByBlock") {
+    throw "filterByBlock should document the stored block-id filter behavior"
+}
+
+Write-Host "Travel filterByBlock single-pass regression passed."

--- a/src/main/java/com/gtocore/eio_travel/logic/TravelUtils.java
+++ b/src/main/java/com/gtocore/eio_travel/logic/TravelUtils.java
@@ -72,6 +72,9 @@ public interface TravelUtils {
         return chunkMap.values().stream();
     }
 
+    /**
+     * Filters travel targets by the block id stored on the travelling staff without materializing the stream.
+     */
     static Stream<ITravelTarget> filterByBlock(Player player, Stream<ITravelTarget> targets) {
         ItemStack stack = player.getMainHandItem().isEmpty() ?
                 player.getOffhandItem() : player.getMainHandItem();
@@ -84,21 +87,7 @@ public interface TravelUtils {
         String filterBlock = tag.getString(FILTER_BLOCK_TAG);
         Level level = player.level();
 
-        List<ITravelTarget> targetList = targets.toList();
-
-        Set<String> existingBlockTypes = new HashSet<>();
-        for (ITravelTarget target : targetList) {
-            BlockPos pos = target.getPos();
-            BlockState blockState = level.getBlockState(pos);
-            String blockId = Objects.requireNonNull(ForgeRegistries.BLOCKS.getKey(blockState.getBlock())).toString();
-            existingBlockTypes.add(blockId);
-        }
-
-        if (!existingBlockTypes.contains(filterBlock)) {
-            return Stream.empty();
-        }
-
-        return targetList.stream().filter(target -> {
+        return targets.filter(target -> {
             BlockPos pos = target.getPos();
             BlockState blockState = level.getBlockState(pos);
             String blockId = Objects.requireNonNull(ForgeRegistries.BLOCKS.getKey(blockState.getBlock())).toString();


### PR DESCRIPTION
## Summary
- Rewrite travel target block filtering into a single-pass loop to avoid repeated stream filters and intermediate list creation.
- Keep existing ordering and distance behavior intact.
- Add a regression script that checks the helper keeps one traversal-oriented filtering path.

## Test Plan
- `scripts\regression\travel_filter_by_block_single_pass.ps1`
- `git diff --check`
- `./gradlew.bat compileJava compileKotlin --no-daemon --console=plain`