### PR TITLE
feat: whitelist all MythicBotany items in Gaia III spawn check

### DIFF
--- a/src/main/java/com/gtocore/mixin/extrabotany/GaiaArenaMixin.java
+++ b/src/main/java/com/gtocore/mixin/extrabotany/GaiaArenaMixin.java
@@ -1,0 +1,26 @@
+package com.gtocore.mixin.extrabotany;
+
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+
+import io.github.lounode.extrabotany.api.gaia.GaiaArena;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(GaiaArena.class)
+public class GaiaArenaMixin {
+
+    @Inject(method = "checkFeasibility", at = @At("HEAD"), cancellable = true, remap = false)
+    private static void gtocore$whitelistMythicBotany(ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
+        if (stack.isEmpty()) {
+            return;
+        }
+        ResourceLocation id = BuiltInRegistries.ITEM.getKey(stack.getItem());
+        if ("mythicbotany".equals(id.getNamespace())) {
+            cir.setReturnValue(true);
+        }
+    }
+}

--- a/src/main/resources/gtocore.mixins.json
+++ b/src/main/resources/gtocore.mixins.json
@@ -141,6 +141,7 @@
     "corgilib.CorgiLibForgeClientEventsMixin",
     "deeperdarker.DDItemsMixin",
     "endremastered.EREnderEyeMixin",
+    "extrabotany.GaiaArenaMixin",
     "farmersdelight.CuttingBoardBlockEntityMixin",
     "ftbq.FTBQuestsCommandsMixin",
     "ftbq.ItemRewardMixin",


### PR DESCRIPTION
## What
Adds `com.gtocore.mixin.extrabotany.GaiaArenaMixin`, which injects into Extrabotany's `GaiaArena#checkFeasibility(ItemStack)` and returns `true` for any item in the `mythicbotany` namespace.

## Why
Extrabotany's Gaia III scans the player's whole inventory on spawn/arena check and blocks the fight if it finds items from non-whitelisted mods (anti-cheese). This whitelists **all of MythicBotany** so its gear no longer blocks Gaia III.

## Notes
- Pure external mixin, no Extrabotany source changes.
- `remap = false` (mod target), consistent with the existing `botania.GaiaGuardianEntityMixin`.
- The mixin references no MythicBotany classes (namespace string only), so it is harmless if MythicBotany is absent.
- Registered in `gtocore.mixins.json`.