### PR TITLE
修复热解炉功率增幅器被线圈顶掉

### DIFF
--- a/src/main/java/com/gtocore/common/data/machines/GTMachineModify.java
+++ b/src/main/java/com/gtocore/common/data/machines/GTMachineModify.java
@@ -20,6 +20,7 @@ import com.gregtechceu.gtceu.api.pattern.TraceabilityPredicate;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 import com.gregtechceu.gtceu.api.recipe.modifier.RecipeModifier;
+import com.gregtechceu.gtceu.api.recipe.modifier.RecipeModifierList;
 import com.gregtechceu.gtceu.common.data.GTBlocks;
 import com.gregtechceu.gtceu.common.data.GTMachines;
 import com.gregtechceu.gtceu.common.data.GTMaterials;
@@ -51,7 +52,7 @@ public final class GTMachineModify {
         GTMultiMachines.MULTI_SMELTER.setRecipeModifier(GTORecipeModifiers.UPGRADE_MULTI_SMELTER_OVERCLOCK);
         GTMultiMachines.LARGE_CHEMICAL_REACTOR.setRecipeModifier(RecipeModifier.NO_MODIFIER);
         GTMultiMachines.ELECTRIC_BLAST_FURNACE.setRecipeModifier(GTORecipeModifiers.UPGRADE_EBF_OVERCLOCK);
-        GTMultiMachines.PYROLYSE_OVEN.setRecipeModifier(GTORecipeModifiers.UPGRADE_PYROLYSE_OVEN_OVERCLOCK);
+        GTMultiMachines.PYROLYSE_OVEN.setRecipeModifier(new RecipeModifierList(GTORecipeModifiers.POWER_AMPLIFIER, GTORecipeModifiers.UPGRADE_PYROLYSE_OVEN_OVERCLOCK));
         GTMultiMachines.PYROLYSE_OVEN.setRecoveryItems(GTMachineModify::tinydustFromDustOutput);
         GTMultiMachines.CRACKER.setRecipeModifier(GTORecipeModifiers.UPGRADE_CRACKER_OVERCLOCK);
         GTMultiMachines.IMPLOSION_COMPRESSOR.setRecipeModifier(GTORecipeModifiers.UPGRADE_OVERCLOCK);


### PR DESCRIPTION
原逻辑/代码的问题：pre3 中热解炉把 GTCEu 的热解炉 modifier 替换成 GTO 的升级热解 modifier，未组合 `GTORecipeModifiers.POWER_AMPLIFIER`，导致功率增幅器加成被热解炉线圈逻辑顶掉。

修复方式：将热解炉 modifier 改为 `RecipeModifierList(GTORecipeModifiers.POWER_AMPLIFIER, GTORecipeModifiers.UPGRADE_PYROLYSE_OVEN_OVERCLOCK)`，先应用增幅器，再应用热解炉升级/线圈超频。

测试命令和结果：
- PowerShell source assertion：通过，确认修复前热解炉 modifier 未组合 `POWER_AMPLIFIER`，修复后已先组合 `POWER_AMPLIFIER` 再组合热解炉超频。
- `./gradlew.bat compileJava --console=plain`：通过，exit 0。
- `git diff --check`：通过，exit 0。

关联 issue：Fixes GregTech-Odyssey/GregTech-Odyssey#1650
完整 issue：https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1650