### PR TITLE
修复 Vajra 与工具头合成误转换

### DIFF
--- a/src/main/java/com/gtocore/mixin/gtm/recipe/ToolHeadReplaceRecipeMixin.java
+++ b/src/main/java/com/gtocore/mixin/gtm/recipe/ToolHeadReplaceRecipeMixin.java
@@ -1,0 +1,49 @@
+package com.gtocore.mixin.gtm.recipe;
+
+import com.gtolib.api.item.tool.GTOToolType;
+
+import com.gregtechceu.gtceu.api.item.IGTTool;
+import com.gregtechceu.gtceu.api.item.tool.GTToolType;
+import com.gregtechceu.gtceu.common.recipe.ToolHeadReplaceRecipe;
+
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.world.inventory.CraftingContainer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = ToolHeadReplaceRecipe.class, remap = false)
+public final class ToolHeadReplaceRecipeMixin {
+
+    @Inject(method = "matches", at = @At("HEAD"), cancellable = true)
+    private void matches(CraftingContainer inv, Level level, CallbackInfoReturnable<Boolean> cir) {
+        if (hasVajra(inv)) {
+            cir.setReturnValue(false);
+        }
+    }
+
+    @Inject(method = "assemble", at = @At("HEAD"), cancellable = true)
+    private void assemble(CraftingContainer inv, RegistryAccess registryAccess, CallbackInfoReturnable<ItemStack> cir) {
+        if (hasVajra(inv)) {
+            cir.setReturnValue(ItemStack.EMPTY);
+        }
+    }
+
+    private static boolean hasVajra(CraftingContainer inv) {
+        for (int i = 0; i < inv.getContainerSize(); i++) {
+            if (inv.getItem(i).getItem() instanceof IGTTool tool && isVajra(tool.getToolType())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isVajra(GTToolType toolType) {
+        return toolType == GTOToolType.VAJRA_HV || toolType == GTOToolType.VAJRA_EV ||
+                toolType == GTOToolType.VAJRA_IV;
+    }
+}

--- a/src/main/resources/gtocore.mixins.json
+++ b/src/main/resources/gtocore.mixins.json
@@ -186,6 +186,7 @@
     "gtm.recipe.DimensionConditionMixin",
     "gtm.recipe.MaceratorLogicMixin",
     "gtm.recipe.RecyclingRecipesMixin",
+    "gtm.recipe.ToolHeadReplaceRecipeMixin",
     "gtm.recipe.WoodMachineRecipesMixin",
     "gtm.registry.GTBedrockFluidsMixin",
     "gtm.registry.GTBlocksMixin",


### PR DESCRIPTION
关联 issue：Fixes GregTech-Odyssey/GregTech-Odyssey#1611

完整 issue：https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1611

问题：GTCEu 的工具头替换配方只按“电动 IGTTool + tier + 工具头前缀”匹配，没有检查当前工具类型，因此 GTO 的 Vajra 会被误转换成钻头、剪线钳或扳手。

修复：新增最小 mixin guard，让工具头替换配方在 matches 和 assemble 中忽略 GTO HV/EV/IV Vajra。

验证：
- 字节码断言：确认 ToolHeadReplaceRecipe 使用 isElectric/getElectricTier，且原逻辑没有 getToolType 限制。
- 源码断言：确认 Vajra guard mixin 已注册，并覆盖 HV/EV/IV Vajra。
- .\gradlew.bat compileJava：BUILD SUCCESSFUL。