### PR TITLE
修复镀层涡轮转子耐久消耗异常

### DIFF
--- a/src/main/java/com/gtocore/mixin/gtm/item/CoatedTurbineRotorBehaviourMixin.java
+++ b/src/main/java/com/gtocore/mixin/gtm/item/CoatedTurbineRotorBehaviourMixin.java
@@ -1,0 +1,50 @@
+package com.gtocore.mixin.gtm.item;
+
+import com.gregtechceu.gtceu.common.item.TurbineRotorBehaviour;
+import com.gregtechceu.gtceu.common.item.tool.CoatedTurbineRotorBehaviour;
+
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(CoatedTurbineRotorBehaviour.class)
+public abstract class CoatedTurbineRotorBehaviourMixin extends TurbineRotorBehaviour {
+
+    @Shadow(remap = false)
+    @Final
+    private RandomSource rd;
+
+    @Shadow(remap = false)
+    public abstract int getCoatDamage(ItemStack itemStack);
+
+    @Shadow(remap = false)
+    public abstract int getCoatMaxDamage(ItemStack itemStack);
+
+    @Shadow(remap = false)
+    public abstract void setCoatDamage(ItemStack itemStack, int resultDamage);
+
+    /**
+     * @author GTOCore
+     * @reason Use rotor durability delta, not entity attack damage, when charging coating wear.
+     */
+    @Overwrite(remap = false)
+    public void setPartDamage(ItemStack itemStack, int resultDamage) {
+        int damageApplied = resultDamage - getPartDamage(itemStack);
+        if (damageApplied <= 0) {
+            super.setPartDamage(itemStack, resultDamage);
+            return;
+        }
+        if (getCoatDamage(itemStack) < getCoatMaxDamage(itemStack) &&
+                rd.nextInt(100) < 95 && !CoatedTurbineRotorBehaviour.isCoatingMagical(itemStack)) {
+            setCoatDamage(itemStack, Math.min(getCoatDamage(itemStack) + damageApplied, getCoatMaxDamage(itemStack)));
+            return;
+        } else if (CoatedTurbineRotorBehaviour.isCoatingMagical(itemStack)) {
+            setCoatDamage(itemStack, getCoatDamage(itemStack) + damageApplied);
+        }
+        super.setPartDamage(itemStack, resultDamage);
+    }
+}

--- a/src/main/resources/gtocore.mixins.json
+++ b/src/main/resources/gtocore.mixins.json
@@ -159,6 +159,7 @@
     "gtm.chemical.MaterialMixin",
     "gtm.chemical.TagPrefixMixin",
     "gtm.item.ColorSprayBehaviourMixin",
+    "gtm.item.CoatedTurbineRotorBehaviourMixin",
     "gtm.item.DataItemBehaviorMixin",
     "gtm.item.MaterialBlockItemMixin",
     "gtm.item.MaterialPipeBlockItemMixin",


### PR DESCRIPTION
关联 issue：Fixes GregTech-Odyssey/GregTech-Odyssey#1336

Issue URL：https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1336

问题：镀层涡轮转子消耗耐久时，原逻辑用转子实体攻击伤害作为差值基准，导致已有本体耐久损耗被反复计入镀层单次消耗，镀层扣除量随本体损耗累加。

修复：覆盖镀层转子的耐久写入逻辑，改为按本次转子耐久变化量扣除镀层耐久。

测试结果：
- PowerShell 断言复现旧公式：body=1999、wear=1 时旧镀层扣除=2000，修复后扣除=1。
- PowerShell 源码断言确认 mixin 使用 resultDamage - getPartDamage(itemStack)，且不再使用 resultDamage - getDamage(itemStack)。
- .\gradlew.bat compileJava 通过。