### PR TITLE
修复可请求输入拆除时 AE2 合成链崩溃

### DIFF
--- a/src/main/java/com/gtocore/mixin/ae2/crafting/CraftingLinkNexusMixin.java
+++ b/src/main/java/com/gtocore/mixin/ae2/crafting/CraftingLinkNexusMixin.java
@@ -1,0 +1,18 @@
+package com.gtocore.mixin.ae2.crafting;
+
+import appeng.api.networking.IGrid;
+import appeng.api.networking.IGridNode;
+import appeng.crafting.CraftingLinkNexus;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(CraftingLinkNexus.class)
+public abstract class CraftingLinkNexusMixin {
+
+    @Redirect(method = "isDead", at = @At(value = "INVOKE", target = "Lappeng/api/networking/IGridNode;getGrid()Lappeng/api/networking/IGrid;"), remap = false)
+    private IGrid gto$missingRequesterNodeIsDead(IGridNode node) {
+        return node == null ? null : node.getGrid();
+    }
+}

--- a/src/main/resources/gtocore.mixins.json
+++ b/src/main/resources/gtocore.mixins.json
@@ -52,6 +52,7 @@
     "ae2.blockentity.StorageBusPartMixin",
     "ae2.crafting.CPUSelectionListMixin",
     "ae2.crafting.CraftingCPUClusterMixin",
+    "ae2.crafting.CraftingLinkNexusMixin",
     "ae2.crafting.CraftingServiceMixin",
     "ae2.crafting.ElapsedTimeTrackerMixin",
     "ae2.crafting.PatternContainerGroupMixin",


### PR DESCRIPTION
## 问题
AE2 `CraftingLinkNexus.isDead` 会直接调用 `ICraftingRequester.getActionableNode().getGrid()`。可请求输入仓/总线在合成状态拆除后，请求方节点可能已经为 null，导致服务端 tick 崩溃。

## 修复
为 `CraftingLinkNexus.isDead` 的 `IGridNode#getGrid` 调用增加最小 redirect：节点为 null 时返回 null，让 AE2 走原有的 `hasMachine=false` 死链取消路径。

## 验证
- `javap` + PowerShell 断言：确认 AE2 15.5.0 仍存在 `getActionableNode()->getGrid` 崩溃路径，且本 mixin 已注册并覆盖该调用，结果 PASS。
- `.\gradlew.bat compileJava`：BUILD SUCCESSFUL。
- `javap` + PowerShell 断言：确认编译后的 redirect class 包含 null guard，结果 PASS。
- `.\gradlew.bat spotlessJavaCheck`：BUILD SUCCESSFUL。

关联 issue：Fixes GregTech-Odyssey/GregTech-Odyssey#1621
Issue URL：https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1621