### PR TITLE
修复等离子冷凝器无损超频

### DIFF
--- a/src/main/java/com/gtocore/common/data/machines/MultiBlockA.java
+++ b/src/main/java/com/gtocore/common/data/machines/MultiBlockA.java
@@ -33,7 +33,9 @@ import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.data.chemical.ChemicalHelper;
 import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.machine.MultiblockMachineDefinition;
+import com.gregtechceu.gtceu.api.machine.feature.IOverclockMachine;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.ICoilMachine;
+import com.gregtechceu.gtceu.api.machine.feature.multiblock.IWorkableMultiController;
 import com.gregtechceu.gtceu.api.machine.multiblock.PartAbility;
 import com.gregtechceu.gtceu.api.pattern.FactoryBlockPattern;
 import com.gregtechceu.gtceu.api.pattern.Predicates;
@@ -131,7 +133,7 @@ public final class MultiBlockA {
 
     public static final MultiblockMachineDefinition PLASMA_CONDENSER = multiblock("plasma_condenser", "等离子冷凝器",
             TierCasingMultiblockMachine.createMachine(GTORecipeDataKeys.GLASS_TIER))
-            .recipeModifier((m, u, r) -> RecipeModifier.overclocking(m, u, r, false, 1, Math.pow(1 / 1.1d, ((ITierCasingMachine) m).getCasingTier(GTORecipeDataKeys.GLASS_TIER)), 0.25))
+            .recipeModifier((m, u, r) -> m instanceof IOverclockMachine oc ? RecipeModifier.overclocking(m, u, r, m instanceof IWorkableMultiController c && c.isBatchEnabled(), 1, r.getInputEUt(), oc.getOverclockVoltage(), false, Math.pow(1 / 1.1d, ((ITierCasingMachine) m).getCasingTier(GTORecipeDataKeys.GLASS_TIER)), 0.25) : r)
             .allRotation()
             .recipeTypes(GTORecipeTypes.PLASMA_CONDENSER_RECIPES)
             .tooltips(GTOMachineStories.PlasmaCondenserTooltips)


### PR DESCRIPTION
## 问题

等离子冷凝器标注为无损超频，但原逻辑沿用默认最小超频时间下限；在 20t 下限触发并行补偿时，每次超频只补 2 倍并行，导致理论无损吞吐损失 8 倍。

## 修复

等离子冷凝器继续保留玻璃等级耗时倍率和 0.25 超频倍率，但调用完整 overclocking 重载，将该机器的最小超频时间固定为 1t，避免 20t 下限把无损超频折成有损吞吐。

## 验证

- `powershell` 临时断言：旧路径 `oldEffectiveTicks=8.7470133789325`，修复路径 `fixedEffectiveTicks=1.09337667236656`，理论值 `theoryTicks=1.09337667236656`，通过。
- `./gradlew compileJava`：通过。
- `./gradlew spotlessJavaCheck`：通过。
- `git diff --check`：通过。

关联 issue：Fixes GregTech-Odyssey/GregTech-Odyssey#1596

Issue URL：https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1596