### PR TITLE
修复狗粮电力烹饪配方

### DIFF
--- a/src/main/java/com/gtocore/data/recipe/classified/ElectricCooking.java
+++ b/src/main/java/com/gtocore/data/recipe/classified/ElectricCooking.java
@@ -259,10 +259,9 @@ final class ElectricCooking {
 
         ELECTRIC_COOKING_RECIPES.recipeBuilder("dog_food")
                 .inputItems(Items.ROTTEN_FLESH.asItem())
-                .inputItems(Items.BONE.asItem())
-                .inputItems(TagUtils.createItemTag(RLUtils.fd("wolf_prey")))
-                .inputItems("farmersdelight:rice")
-                .inputItems(Items.BOWL.asItem())
+                .inputItems(Items.BONE_MEAL.asItem())
+                .inputItems(TagUtils.createForgeItemTag("raw_meat"))
+                .inputItems(TagUtils.createForgeItemTag("crops/rice"))
                 .outputItems("farmersdelight:dog_food")
                 .circuitMeta(1)
                 .EUt(120)


### PR DESCRIPTION
## 问题
电力烹饪的狗粮配方还在使用旧版 Farmer's Delight 输入：骨头、`farmersdelight:wolf_prey` 和碗；当前依赖中的原狗粮配方已经改为骨粉、`#forge:raw_meat` 和 `#forge:crops/rice`，导致机器匹配不到玩家按现配方放入的材料。

## 修复
将 `dog_food` 电力烹饪配方同步为当前 Farmer's Delight 狗粮输入，并移除多余的碗需求。

## 验证
- 临时 PowerShell 断言：通过。确认 `origin/pre3` 使用旧输入，当前 Farmer's Delight jar 的 `dog_food.json` 使用 `rotten_flesh`、`bone_meal`、`#forge:raw_meat`、`#forge:crops/rice`。
- 临时 PowerShell 断言：通过。确认修复后的 `ElectricCooking.java` 已使用骨粉、`raw_meat`、`crops/rice`，且狗粮配方不再包含 `wolf_prey` 或碗。
- `./gradlew.bat compileJava`：通过。
- `./gradlew.bat runData`：失败于现有 datagen 启动期 mixin 冲突 `modernfix ... IngredientMixin` 与 `com.gtolib.mixin.mc.recipe.IngredientMixin`，在本次修改前后的配方代码之外；该任务在失败前已完成 `compileJava`。

关联 issue：Fixes GregTech-Odyssey/GregTech-Odyssey#1603
Issue URL: https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1603