### PR TITLE
修复雾化冷凝器自定义并行未生效

### DIFF
--- a/src/main/java/com/gtocore/common/data/machines/MultiBlockH.java
+++ b/src/main/java/com/gtocore/common/data/machines/MultiBlockH.java
@@ -12,6 +12,7 @@ import com.gtocore.common.machine.multiblock.steam.LargeSteamSolarBoilerMachine;
 
 import com.gtolib.GTOCore;
 import com.gtolib.api.annotation.NewDataAttributes;
+import com.gtolib.api.machine.feature.multiblock.IParallelMachine;
 import com.gtolib.api.machine.feature.multiblock.ITierCasingMachine;
 import com.gtolib.api.machine.impl.EncapsulatorExecutionModuleMachine;
 import com.gtolib.api.machine.impl.ProcessingEncapsulatorMachine;
@@ -27,6 +28,7 @@ import com.gregtechceu.gtceu.api.data.tag.TagPrefix;
 import com.gregtechceu.gtceu.api.machine.MultiblockMachineDefinition;
 import com.gregtechceu.gtceu.api.pattern.FactoryBlockPattern;
 import com.gregtechceu.gtceu.api.pattern.MultiblockShapeInfo;
+import com.gregtechceu.gtceu.api.recipe.modifier.ParallelLogic;
 import com.gregtechceu.gtceu.api.recipe.modifier.RecipeModifier;
 import com.gregtechceu.gtceu.common.data.*;
 
@@ -806,7 +808,7 @@ public final class MultiBlockH {
             .specialParallelizableTooltips()
             .tooltips(GTOMachineStories.atomizingCondenserTooltips)
             .recipeTypes(GTORecipeTypes.ATOMIZATION_CONDENSATION_RECIPES)
-            .recipeModifier(GTORecipeModifiers.UPGRADE_GCYM_OVERCLOCKING)
+            .recipeModifiers((m, u, r) -> ParallelLogic.accurateParallel(m, u, r, ((IParallelMachine) m).getParallel()), GTORecipeModifiers.UPGRADE_GCYM_OVERCLOCKING)
             .block(GTBlocks.CASING_ALUMINIUM_FROSTPROOF)
             .tooltips(NewDataAttributes.ALLOW_PARALLEL_NUMBER.create(h -> h.addLines("(密封机械方块等级)×4", "(Hermetic Mechanical Casing tier)×4")))
             .pattern(definition -> MultiBlockFileReader.start(definition)


### PR DESCRIPTION
## 问题
雾化冷凝器使用 `TierCasingParallelMultiblockMachine` 暴露并行设置，但配方 modifier 只走 `GTORecipeModifiers.UPGRADE_GCYM_OVERCLOCKING`，没有把机器当前 `getParallel()` 传入 `ParallelLogic.accurateParallel(...)`，导致 UI 设置 24 并行时输入仍按 1 并行消耗。

## 修复
在雾化冷凝器的 modifier 链中先按 `IParallelMachine#getParallel()` 执行 `ParallelLogic.accurateParallel(...)`，再保留原 GCYM 升级/超频逻辑。

## 验证
- `git show origin/pre3:src/main/java/com/gtocore/common/data/machines/MultiBlockH.java` + PowerShell 断言：确认 pre3 雾化冷凝器只有 `UPGRADE_GCYM_OVERCLOCKING`，当前分支已绑定 `getParallel()` 到 `accurateParallel()`，结果 `ASSERT OK`。
- `javap ... com.gregtechceu.gtceu.api.recipe.modifier.ParallelLogic` + PowerShell 断言：确认 `accurateParallel` 会调用 `GTRecipe.modifier(JZ)`，当前分支传入 UI 并行值，结果 `ASSERT OK`。
- `git diff --check`：通过。
- `./gradlew.bat compileJava`：BUILD SUCCESSFUL。

关联 issue：Fixes GregTech-Odyssey/GregTech-Odyssey#1507
完整链接：https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1507