### PR TITLE
修复原始蒸馏塔无法处理蒸汽裂化石脑油

### DIFF
--- a/src/main/java/com/gtocore/common/machine/multiblock/noenergy/PrimitiveDistillationTowerMachine.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/noenergy/PrimitiveDistillationTowerMachine.java
@@ -14,6 +14,7 @@ import com.gregtechceu.gtceu.api.machine.feature.multiblock.IDistillationTower;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiPart;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
 import com.gregtechceu.gtceu.api.recipe.handler.RecipeHandlerUnit;
+import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
@@ -75,6 +76,24 @@ public final class PrimitiveDistillationTowerMachine extends NoEnergyMultiblockM
         } else {
             return false;
         }
+    }
+
+    @Override
+    public boolean matchRecipeOutput(GTRecipe recipe) {
+        return IDistillationTower.super.matchRecipeOutput(recipe) || IDistillationTower.super.matchRecipeOutput(withoutOptionalItemOutputs(recipe));
+    }
+
+    @Override
+    public boolean handleRecipeOutput(GTRecipe recipe) {
+        if (IDistillationTower.super.matchRecipeOutput(recipe)) return IDistillationTower.super.handleRecipeOutput(recipe);
+        return IDistillationTower.super.handleRecipeOutput(withoutOptionalItemOutputs(recipe));
+    }
+
+    private GTRecipe withoutOptionalItemOutputs(GTRecipe recipe) {
+        if (recipe.definition.recipeType != GTRecipeTypes.DISTILLATION_RECIPES || recipe.itemOutputs.isEmpty()) return recipe;
+        var copy = recipe.copy();
+        copy.itemOutputs = Collections.emptyList();
+        return copy;
     }
 
     private double getDurationMultiplier(double temperatureA, double temperatureB) {

--- a/src/main/java/com/gtocore/common/machine/multiblock/noenergy/PrimitiveDistillationTowerMachine.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/noenergy/PrimitiveDistillationTowerMachine.java
@@ -13,6 +13,7 @@ import com.gregtechceu.gtceu.api.machine.feature.IExplosionMachine;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IDistillationTower;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiPart;
 import com.gregtechceu.gtceu.api.recipe.GTRecipe;
+import com.gregtechceu.gtceu.api.recipe.content.Content;
 import com.gregtechceu.gtceu.api.recipe.handler.RecipeHandlerUnit;
 import com.gregtechceu.gtceu.common.data.GTRecipeTypes;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
@@ -80,17 +81,21 @@ public final class PrimitiveDistillationTowerMachine extends NoEnergyMultiblockM
 
     @Override
     public boolean matchRecipeOutput(GTRecipe recipe) {
-        return IDistillationTower.super.matchRecipeOutput(recipe) || IDistillationTower.super.matchRecipeOutput(withoutOptionalItemOutputs(recipe));
+        if (IDistillationTower.super.matchRecipeOutput(recipe)) return true;
+        var optional = withoutOptionalItemOutputs(recipe);
+        return optional != recipe && IDistillationTower.super.matchRecipeOutput(optional);
     }
 
     @Override
     public boolean handleRecipeOutput(GTRecipe recipe) {
         if (IDistillationTower.super.matchRecipeOutput(recipe)) return IDistillationTower.super.handleRecipeOutput(recipe);
-        return IDistillationTower.super.handleRecipeOutput(withoutOptionalItemOutputs(recipe));
+        var optional = withoutOptionalItemOutputs(recipe);
+        return optional != recipe && IDistillationTower.super.handleRecipeOutput(optional);
     }
 
     private GTRecipe withoutOptionalItemOutputs(GTRecipe recipe) {
         if (recipe.definition.recipeType != GTRecipeTypes.DISTILLATION_RECIPES || recipe.itemOutputs.isEmpty()) return recipe;
+        if (recipe.itemOutputs.stream().anyMatch(content -> content.chance >= Content.MAX_CHANCE)) return recipe;
         var copy = recipe.copy();
         copy.itemOutputs = Collections.emptyList();
         return copy;


### PR DESCRIPTION
## 问题
原始蒸馏塔复用蒸馏塔输出匹配时，会要求配方的物品副产物也能输出。严重/重度蒸汽裂化石脑油蒸馏配方带碳粉概率副产物，未放物品输出仓时会被判定为没有配方；原油配方没有物品副产物所以正常。

## 修复
原始蒸馏塔先按原逻辑匹配输出；若失败，仅当蒸馏配方的物品输出全部为概率输出（`chance < Content.MAX_CHANCE`）时，复制配方并清空这些概率物品输出后重试。含 100% 必定物品输出的蒸馏配方仍沿用原逻辑，继续要求物品输出仓。

## 验证
- 临时静态断言：`ASSERT_OK: fallback is guarded to chanced item outputs; guaranteed item output recipe remains covered by original logic`
- `git diff --check` 通过
- `.\gradlew.bat compileJava` 通过

关联 issue：Fixes GregTech-Odyssey/GregTech-Odyssey#1668
Issue URL：https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1668