### PR TITLE
修复跨配方独立线程调度

### DIFF
--- a/src/main/java/com/gtocore/mixin/gtolib/ICrossRecipeMachineMixin.java
+++ b/src/main/java/com/gtocore/mixin/gtolib/ICrossRecipeMachineMixin.java
@@ -22,6 +22,7 @@ public interface ICrossRecipeMachineMixin {
      */
     @Overwrite
     default boolean isIndependentThread() {
-        return getCrossRecipeTrait().isSeparateThread && isRepeatedRecipes();
+        var threadHatch = getCrossRecipeTrait().threadHatchPartMachine;
+        return (threadHatch == null || threadHatch.isIThread()) && isRepeatedRecipes();
     }
 }

--- a/src/main/java/com/gtocore/mixin/gtolib/ICrossRecipeMachineMixin.java
+++ b/src/main/java/com/gtocore/mixin/gtolib/ICrossRecipeMachineMixin.java
@@ -1,0 +1,27 @@
+package com.gtocore.mixin.gtolib;
+
+import com.gtolib.api.machine.feature.multiblock.ICrossRecipeMachine;
+import com.gtolib.api.machine.trait.CrossRecipeTrait;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(value = ICrossRecipeMachine.class, remap = false)
+public interface ICrossRecipeMachineMixin {
+
+    @Shadow
+    CrossRecipeTrait getCrossRecipeTrait();
+
+    @Shadow
+    boolean isRepeatedRecipes();
+
+    /**
+     * @author Codex
+     * @reason Keep non-repeated mode on the cross-recipe scheduler; gtolib's independent-thread path parallelizes the first recipe.
+     */
+    @Overwrite
+    default boolean isIndependentThread() {
+        return getCrossRecipeTrait().isSeparateThread && isRepeatedRecipes();
+    }
+}

--- a/src/main/resources/gtocore.mixins.json
+++ b/src/main/resources/gtocore.mixins.json
@@ -197,6 +197,7 @@
     "gtm.registry.GTOresMixin",
     "gtm.registry.GTRecipeTypesMixin",
     "gtm.registry.GTRegistrationMixin",
+    "gtolib.ICrossRecipeMachineMixin",
     "guideme.GuideMEMixin",
     "jade.CommonProxyMixin",
     "jade.JadeForgeUtilsMixin",


### PR DESCRIPTION
## 问题

跨配方机器在关闭“并行重复配方”但开启独立线程时，会进入 gtolib 的独立线程路径；该路径会把可用线程集中用于首个匹配配方，导致没有按不同配方分配线程。

## 修复

新增 `ICrossRecipeMachine` mixin：独立线程判断保留线程仓开关语义，直接读取 `threadHatchPartMachine.isIThread()`；只有“线程仓独立线程开启”且“并行重复配方开启”时，才继续使用独立线程路径。并行重复配方关闭时回到跨配方调度路径，避免把所有线程集中到第一个配方。

## 验证

- `./gradlew.bat classes`：通过
- `javap -classpath 'build/classes/java/main;libs/gtolib-1.0.jar' -c -private com.gtocore.mixin.gtolib.ICrossRecipeMachineMixin`：通过，字节码确认读取 `threadHatchPartMachine` 并调用 `ThreadPartMachine.isIThread()`
- 临时 PowerShell 真值表断言：通过，覆盖“独立线程 on/off × 并行重复配方 on/off”，并确认不再使用运行态 `isSeparateThread && ...` 判断

关联 issue：Fixes GregTech-Odyssey/GregTech-Odyssey#1569

完整 issue：https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1569