### PR TITLE
修复大型炼金装置概率增强输出

### DIFF
--- a/src/main/java/com/gtocore/common/machine/mana/AlchemyCauldron.java
+++ b/src/main/java/com/gtocore/common/machine/mana/AlchemyCauldron.java
@@ -75,12 +75,12 @@ public class AlchemyCauldron extends SimpleManaMachine implements IHeatContainer
         int matchRate = calculateMatchRate(recipeParams);
 
         recipe.itemOutputs = recipe.itemOutputs.stream().map(content -> {
-            if (content.chance < 11) return new Content<>(content.inner, matchRate, 0);
+            if (content.chance < 11 || content.tierChanceBoost > 0) return new Content<>(content.inner, matchRate, 0);
             else return content;
         }).toList();
 
         recipe.fluidOutputs = recipe.fluidOutputs.stream().map(content -> {
-            if (content.chance < 11) return new Content<>(content.inner, matchRate, 0);
+            if (content.chance < 11 || content.tierChanceBoost > 0) return new Content<>(content.inner, matchRate, 0);
             else return content;
         }).toList();
 
@@ -93,7 +93,7 @@ public class AlchemyCauldron extends SimpleManaMachine implements IHeatContainer
     private int calculateMatchRate(int[] recipeParams) {
         int distance = calculateDistance(probabilityParams, recipeParams);
         if (distance <= 0) return 10000;
-        else if (distance <= 5) return 9000;
+        else if (distance <= 5) return 10000;
         else if (distance >= 3000) return 1;
         float linear = (1 - distance * 3.3333333E-4F);
         float exponential = (float) Math.exp((1000 - distance) * 5.0E-4F);

--- a/src/main/java/com/gtocore/common/machine/mana/multiblock/LargeAlchemicalDeviceMachine.java
+++ b/src/main/java/com/gtocore/common/machine/mana/multiblock/LargeAlchemicalDeviceMachine.java
@@ -65,12 +65,12 @@ public final class LargeAlchemicalDeviceMachine extends ManaMultiblockMachine {
         int matchRate = calculateMatchRate(recipeParams);
 
         recipe.itemOutputs = recipe.itemOutputs.stream().map(content -> {
-            if (content.chance < 11) return new Content<>(content.inner, matchRate, 0);
+            if (content.chance < 11 || content.tierChanceBoost > 0) return new Content<>(content.inner, matchRate, 0);
             else return content;
         }).toList();
 
         recipe.fluidOutputs = recipe.fluidOutputs.stream().map(content -> {
-            if (content.chance < 11) return new Content<>(content.inner, matchRate, 0);
+            if (content.chance < 11 || content.tierChanceBoost > 0) return new Content<>(content.inner, matchRate, 0);
             else return content;
         }).toList();
 
@@ -85,7 +85,7 @@ public final class LargeAlchemicalDeviceMachine extends ManaMultiblockMachine {
         int distance = calculateDistance(probabilityParams, recipeParams);
 
         if (distance <= 0) return 10000;
-        else if (distance <= 5) return 9000;
+        else if (distance <= 5) return 10000;
         else if (distance >= 3000) return 1;
 
         float linear = (1 - distance * 0.00033333333f);


### PR DESCRIPTION
原逻辑/代码问题：炼金参数增强只处理 `chance < 11` 的输出，导致幻影离子液配方的主输出 `5000, 625` 不会被模块/匹配率提升；同时参数距离小于等于 5 时返回 90%，目标 11400 这类值会收敛到 11399 后卡在 90%。

修复方式：带 `tierChanceBoost` 的炼金输出也使用匹配率重写概率；参数距离小于等于 5 时视为满匹配，返回 100%。

测试命令和结果：
- 临时 PowerShell 断言：通过，确认增强判定、11400 收敛和幻影离子液配方主输出。
- `./gradlew.bat compileJava`：通过，BUILD SUCCESSFUL。

关联 issue：https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1548

Fixes GregTech-Odyssey/GregTech-Odyssey#1548