### PR TITLE
修复 ME 能源塔缓存上限

### DIFF
--- a/src/main/java/com/gtocore/common/machine/multiblock/part/ae/MEEnergyAccessPartMachine.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/part/ae/MEEnergyAccessPartMachine.java
@@ -10,12 +10,17 @@ import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
 import com.gregtechceu.gtceu.api.recipe.handler.IO;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 
+import net.minecraft.nbt.CompoundTag;
+
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.Actionable;
 import appeng.api.config.PowerMultiplier;
 import appeng.api.config.PowerUnits;
+import appeng.api.networking.IGrid;
+import appeng.api.networking.IGridNode;
 import appeng.api.networking.energy.IAEPowerStorage;
 import appeng.api.networking.events.GridPowerStorageStateChanged;
+import appeng.me.service.EnergyService;
 
 import com.lowdragmc.lowdraglib.gui.widget.LabelWidget;
 import com.lowdragmc.lowdraglib.gui.widget.Widget;
@@ -58,24 +63,47 @@ public class MEEnergyAccessPartMachine extends MEPartMachine implements IAEPower
         if (controller == null) {
             return;
         }
-        this.ratio = ConfigHolder.INSTANCE.compat.energy.euToFeRatio;
-        this.ratio *= 1 + 0.3 * controller.getCasingTier(GTORecipeDataKeys.GLASS_TIER);
-        this.ratio *= controller.getSubFormedAmount() + 1;
+        updateRatio();
         if (this.getMainNode().getGrid() != null) {
             this.getMainNode().getGrid().postEvent(new GridPowerStorageStateChanged(this, GridPowerStorageStateChanged.PowerEventType.PROVIDE_POWER));
+        }
+    }
+
+    private void updateRatio() {
+        this.ratio = ConfigHolder.INSTANCE.compat.energy.euToFeRatio;
+        if (controller != null) {
+            this.ratio *= 1 + 0.3 * controller.getCasingTier(GTORecipeDataKeys.GLASS_TIER);
+            this.ratio *= controller.getSubFormedAmount() + 1;
+        }
+    }
+
+    private void refreshEnergyService(Runnable change) {
+        IGridNode node = this.getMainNode().getNode();
+        IGrid grid = this.getMainNode().getGrid();
+        if (node != null && grid != null && grid.getEnergyService() instanceof EnergyService energyService) {
+            CompoundTag savedData = new CompoundTag();
+            energyService.saveNodeData(node, savedData);
+            energyService.removeNode(node);
+            change.run();
+            updateRatio();
+            energyService.addNode(node, savedData);
+        } else {
+            change.run();
+            updateRatio();
         }
     }
 
     @Override
     public void removedFromController(@NotNull IMultiController controller) {
         super.removedFromController(controller);
-        this.controller = null;
+        refreshEnergyService(() -> this.controller = null);
     }
 
     @Override
     public void addedToController(@NotNull IMultiController controller) {
         super.addedToController(controller);
-        this.controller = (TierCasingMultiblockMachine) controller;
+        TierCasingMultiblockMachine newController = (TierCasingMultiblockMachine) controller;
+        refreshEnergyService(() -> this.controller = newController);
         postEnergyEvent();
     }
 

--- a/src/main/java/com/gtocore/common/machine/multiblock/part/ae/MEEnergyAccessPartMachine.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/part/ae/MEEnergyAccessPartMachine.java
@@ -92,7 +92,10 @@ public class MEEnergyAccessPartMachine extends MEPartMachine implements IAEPower
 
     @Override
     public double getAEMaxPower() {
-        return Long.MAX_VALUE;
+        if (controller == null) {
+            return 0;
+        }
+        return EU2AE(controller.getEnergyContainer().getEnergyCapacity());
     }
 
     @Override
@@ -111,7 +114,7 @@ public class MEEnergyAccessPartMachine extends MEPartMachine implements IAEPower
 
     @Override
     public AccessRestriction getPowerFlow() {
-        return AccessRestriction.READ_WRITE;
+        return AccessRestriction.READ;
     }
 
     @Override

--- a/src/main/java/com/gtocore/common/machine/multiblock/part/ae/MEEnergyAccessPartMachine.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/part/ae/MEEnergyAccessPartMachine.java
@@ -11,6 +11,8 @@ import com.gregtechceu.gtceu.api.recipe.handler.IO;
 import com.gregtechceu.gtceu.config.ConfigHolder;
 
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.TickTask;
+import net.minecraft.server.level.ServerLevel;
 
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.Actionable;
@@ -93,6 +95,17 @@ public class MEEnergyAccessPartMachine extends MEPartMachine implements IAEPower
         }
     }
 
+    private void scheduleEnergyServiceRefresh(TierCasingMultiblockMachine expectedController) {
+        if (getLevel() instanceof ServerLevel serverLevel) {
+            serverLevel.getServer().tell(new TickTask(1, () -> {
+                if (this.controller == expectedController && expectedController.isFormed()) {
+                    refreshEnergyService(() -> {});
+                    postEnergyEvent();
+                }
+            }));
+        }
+    }
+
     @Override
     public void removedFromController(@NotNull IMultiController controller) {
         super.removedFromController(controller);
@@ -103,8 +116,9 @@ public class MEEnergyAccessPartMachine extends MEPartMachine implements IAEPower
     public void addedToController(@NotNull IMultiController controller) {
         super.addedToController(controller);
         TierCasingMultiblockMachine newController = (TierCasingMultiblockMachine) controller;
-        refreshEnergyService(() -> this.controller = newController);
-        postEnergyEvent();
+        this.controller = newController;
+        updateRatio();
+        scheduleEnergyServiceRefresh(newController);
     }
 
     @Override


### PR DESCRIPTION
原逻辑的问题：ME 能量访问仓曾把 AE 最大储能上限固定报成 Long.MAX_VALUE，同时以 READ_WRITE 暴露给 AE 网络，导致网络显示极大缓存上限，并把它当作可充电存储。首次改为读取控制器能量容器后，AE2 的 EnergyService 仍会缓存 providerPowerSum；如果在 addedToController 中立刻 remove/add，GTCEu 此时还没完成 energyContainer = new EnergyContainerList(containers)，仍可能把 0 或旧容量采样进 AE 网络。

修复方式：最大储能使用控制器真实 EU 缓存容量折算为 AE，访问方向保持只允许 AE 网络抽取。结构失效时继续先按旧 controller 通过 EnergyService save/remove/add 扣掉旧容量，再清空 controller。结构成型时只记录新 controller 并更新倍率，延后一 server tick，在 controller 未变化且仍 formed 后再 save/remove/add，让 AE2 在控制器 energyContainer 建好之后重新采样真实容量；未入网或 grid 为空时保留 null guard，只更新本地状态。

测试命令和结果：
- 临时源码断言：通过，确认 addedToController 不再同步 add 0、下一 tick 才执行 save/remove/add、removedFromController 仍清旧容量、nullable grid guard 保留、访问方向为 READ、容量来自控制器 energyContainer。
- git diff --check：通过。
- .\gradlew.bat compileJava：通过。

关联 issue：https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1354
Fixes GregTech-Odyssey/GregTech-Odyssey#1354