### PR TITLE
修复源质钢物品重复注册

### DIFF
--- a/src/main/java/com/gtocore/common/data/material/MagicMaterial.java
+++ b/src/main/java/com/gtocore/common/data/material/MagicMaterial.java
@@ -412,7 +412,7 @@ public final class MagicMaterial {
                 .color(0xf766a7)
                 .secondaryColor(0xf768d4)
                 .iconSet(BRIGHT)
-                .toolStats(ToolProperty.Builder.of(6.0F, 7, 8000, 5, GTToolType.SWORD, GTToolType.PICKAXE, GTToolType.SHOVEL, GTToolType.AXE, GTToolType.HOE, GTToolType.MINING_HAMMER, GTToolType.SPADE, GTToolType.SAW, GTToolType.HARD_HAMMER, GTToolType.WRENCH, GTToolType.FILE, GTToolType.CROWBAR, GTToolType.SCREWDRIVER, GTToolType.WIRE_CUTTER, GTToolType.SCYTHE, GTToolType.KNIFE, GTToolType.BUTCHERY_KNIFE, GTToolType.DRILL_LV, GTToolType.DRILL_MV, GTToolType.DRILL_HV, GTToolType.DRILL_EV, GTToolType.DRILL_IV, GTToolType.CHAINSAW_LV, GTToolType.WRENCH_LV, GTToolType.WRENCH_HV, GTToolType.WRENCH_IV, GTToolType.BUZZSAW, GTToolType.SCREWDRIVER_LV, GTToolType.WIRE_CUTTER_LV, GTToolType.WIRE_CUTTER_HV, GTToolType.WIRE_CUTTER_IV).build())
+                .toolStats(ToolProperty.Builder.of(6.0F, 7, 8000, 5, GTToolType.MINING_HAMMER, GTToolType.SPADE, GTToolType.SAW, GTToolType.HARD_HAMMER, GTToolType.WRENCH, GTToolType.FILE, GTToolType.CROWBAR, GTToolType.SCREWDRIVER, GTToolType.WIRE_CUTTER, GTToolType.SCYTHE, GTToolType.KNIFE, GTToolType.BUTCHERY_KNIFE, GTToolType.DRILL_LV, GTToolType.DRILL_MV, GTToolType.DRILL_HV, GTToolType.DRILL_EV, GTToolType.DRILL_IV, GTToolType.CHAINSAW_LV, GTToolType.WRENCH_LV, GTToolType.WRENCH_HV, GTToolType.WRENCH_IV, GTToolType.BUZZSAW, GTToolType.SCREWDRIVER_LV, GTToolType.WIRE_CUTTER_LV, GTToolType.WIRE_CUTTER_HV, GTToolType.WIRE_CUTTER_IV).build())
                 .rotorStats(200, 150, 7.0f, 1600)
                 .buildAndRegister();
 

--- a/src/main/java/com/gtocore/common/data/material/MaterialIgnored.java
+++ b/src/main/java/com/gtocore/common/data/material/MaterialIgnored.java
@@ -26,8 +26,11 @@ import static com.gtocore.api.data.tag.GTOTagPrefix.*;
 import static com.gtocore.common.data.GTOItems.*;
 import static com.gtocore.common.data.GTOMaterials.*;
 import static mythicbotany.register.ModBlocks.alfsteelBlock;
+import static mythicbotany.register.ModBlocks.elementiumOre;
+import static mythicbotany.register.ModBlocks.rawElementiumBlock;
 import static mythicbotany.register.ModItems.alfsteelIngot;
 import static mythicbotany.register.ModItems.alfsteelNugget;
+import static mythicbotany.register.ModItems.rawElementium;
 
 public final class MaterialIgnored {
 
@@ -119,6 +122,9 @@ public final class MaterialIgnored {
         TagPrefix.ingot.setIgnored(Elementium, () -> () -> BotaniaItems.elementium);
         TagPrefix.nugget.setIgnored(Elementium, () -> () -> BotaniaItems.elementiumNugget);
         TagPrefix.block.setIgnored(Elementium, () -> BotaniaBlocks.elementiumBlock);
+        TagPrefix.rawOre.setIgnored(Elementium, () -> () -> rawElementium);
+        TagPrefix.rawOreBlock.setIgnored(Elementium, () -> rawElementiumBlock);
+        LIVING_STONE.setIgnored(Elementium, () -> elementiumOre);
         TagPrefix.ingot.setIgnored(Gaia, () -> () -> BotaniaItems.gaiaIngot);
         TagPrefix.gem.setIgnored(ManaDiamond, () -> () -> BotaniaItems.manaDiamond);
         TagPrefix.block.setIgnored(ManaDiamond, () -> BotaniaBlocks.manaDiamondBlock);


### PR DESCRIPTION
原逻辑会继续由 GTO/GTCEu 为 Elementium 生成原矿、原矿块、矿石和基础工具；这些条目已由 MythicBotany/Botania 注册，导致同名物品重复显示。

修复方式：Elementium 原矿、原矿块、矿石前缀委托给 MythicBotany；基础五件工具交给 Botania，仅保留 GTO 独有材料工具。

测试命令和结果：
- `git diff --check`：通过
- PowerShell 源码断言：通过，确认 raw/ore 委托存在且 Elementium 不再生成 Sword/Pickaxe/Shovel/Axe/Hoe
- `./gradlew compileJava`：通过

关联 issue：https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1335
Fixes GregTech-Odyssey/GregTech-Odyssey#1335