### PR TITLE
修复重进游戏后样板内容终端替换未刷新

### DIFF
--- a/src/main/java/com/gtocore/integration/ae/PatternContentAccessTerminalPart.java
+++ b/src/main/java/com/gtocore/integration/ae/PatternContentAccessTerminalPart.java
@@ -18,6 +18,7 @@ import appeng.api.stacks.AEKey;
 import appeng.api.stacks.GenericStack;
 import appeng.helpers.IConfigInvHost;
 import appeng.helpers.externalstorage.GenericStackInv;
+import appeng.hooks.ticking.TickHandler;
 import appeng.items.parts.PartModels;
 import appeng.menu.MenuOpener;
 import appeng.menu.locator.MenuLocators;
@@ -44,6 +45,7 @@ public class PatternContentAccessTerminalPart extends AbstractDisplayPart implem
     private final ConfigInventory config;
 
     private volatile AEKeySubstitutionMap substitutionMap = AEKeySubstitutionMap.EMPTY;
+    private boolean refreshQueued;
 
     public PatternContentAccessTerminalPart(IPartItem<?> partItem) {
         super(partItem, false);
@@ -79,11 +81,21 @@ public class PatternContentAccessTerminalPart extends AbstractDisplayPart implem
     }
 
     public void refreshPatterns() {
-        if (getMainNode() == null || !getMainNode().isOnline()) return;
-        var grid = getMainNode().getGrid();
-        if (grid != null) {
-            AEPatternRefresher.refresh(grid);
-        }
+        if (refreshQueued || isClientSide()) return;
+        refreshQueued = true;
+        TickHandler.instance().addCallable(getLevel(), () -> {
+            refreshQueued = false;
+            var node = getMainNode();
+            if (node == null || !node.isOnline()) return;
+            if (!node.hasGridBooted()) {
+                refreshPatterns();
+                return;
+            }
+            var grid = node.getGrid();
+            if (grid != null) {
+                AEPatternRefresher.refresh(grid);
+            }
+        });
     }
 
     @Override
@@ -102,6 +114,12 @@ public class PatternContentAccessTerminalPart extends AbstractDisplayPart implem
     @Override
     public GenericStackInv getConfig() {
         return this.config;
+    }
+
+    @Override
+    public void addToWorld() {
+        super.addToWorld();
+        refreshPatterns();
     }
 
     @Override


### PR DESCRIPTION
原逻辑/代码的问题：样板内容管理终端读档后会重建替换表，但供应器样板缓存可能已在 AE2 grid boot 未完成时先解码，导致替换列表未进入缓存。

修复方式：终端加入世界或节点状态变化时，合并到下一 tick 刷新；若 grid 仍在 boot，则继续等待，直到 boot 完成后再刷新供应器样板缓存。

测试命令和结果：`.\gradlew compileJava`，成功；`git diff --check`，无输出。

关联 issue：https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1372

Fixes GregTech-Odyssey/GregTech-Odyssey#1372