### PR TITLE
修复 16x OPV 电池箱满槽无线充电

### DIFF
--- a/src/main/java/com/gtocore/mixin/gtm/machine/BatteryBufferEnergyTraitMixin.java
+++ b/src/main/java/com/gtocore/mixin/gtm/machine/BatteryBufferEnergyTraitMixin.java
@@ -1,13 +1,17 @@
 package com.gtocore.mixin.gtm.machine;
 
+import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.capability.compat.FeCompat;
 import com.gregtechceu.gtceu.api.capability.item.IElectricItem;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
 import com.gregtechceu.gtceu.api.machine.trait.NotifiableEnergyContainer;
 import com.gregtechceu.gtceu.common.machine.electric.BatteryBufferMachine;
+import com.gregtechceu.gtceu.utils.GTUtil;
 
+import net.minecraft.core.Direction;
 import net.minecraftforge.energy.IEnergyStorage;
 
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -22,6 +26,9 @@ public abstract class BatteryBufferEnergyTraitMixin extends NotifiableEnergyCont
     @Shadow
     @Final
     private BatteryBufferMachine this$0;
+
+    @Shadow
+    protected abstract void changed();
 
     protected BatteryBufferEnergyTraitMixin(MetaMachine machine, long maxCapacity, long maxInputVoltage, long maxInputAmperage, long maxOutputVoltage, long maxOutputAmperage) {
         super(machine, maxCapacity, maxInputVoltage, maxInputAmperage, maxOutputVoltage, maxOutputAmperage);
@@ -42,6 +49,56 @@ public abstract class BatteryBufferEnergyTraitMixin extends NotifiableEnergyCont
         cir.setReturnValue(energyStored);
     }
 
+    @Inject(method = "acceptEnergyFromNetwork", at = @At("HEAD"), cancellable = true)
+    private void acceptEnergyFromNetwork(Object o, @Nullable Direction side, long voltage, long energyToAdd, CallbackInfoReturnable<Long> cir) {
+        if (side != null && !inputsEnergy(side)) {
+            cir.setReturnValue(0L);
+            return;
+        }
+        if (voltage > getInputVoltage()) {
+            this$0.doExplosion(GTUtil.getExplosionPower(voltage));
+            cir.setReturnValue(0L);
+            return;
+        }
+
+        var batteries = ((BatteryBufferMachineAccess) this$0).gtocore$getNonFullBatteries();
+        var size = batteries.size();
+        if (size == 0) {
+            cir.setReturnValue(0L);
+            return;
+        }
+
+        long canAccept = Math.min(size * voltage, Math.min(energyToAdd, gtocore$getEnergyCanBeInserted(batteries)));
+        if (canAccept == 0) {
+            cir.setReturnValue(0L);
+            return;
+        }
+
+        long distributed = canAccept / size;
+        if (distributed == 0) {
+            distributed = voltage;
+        }
+
+        long energyAdded = 0;
+        for (Object item : batteries) {
+            long charged = 0;
+            if (item instanceof IElectricItem electricItem) {
+                charged = electricItem.charge(Math.min(distributed, Math.min(canAccept, GTValues.V[electricItem.getTier()])), this$0.getTier(), true, false);
+            } else if (item instanceof IEnergyStorage energyStorage) {
+                charged = FeCompat.insertEu(energyStorage, Math.min(distributed, Math.min(canAccept, GTValues.V[this$0.getTier()])), false);
+            }
+            if (charged > 0) {
+                canAccept -= charged;
+                energyAdded += charged;
+                if (canAccept < 1) break;
+            }
+        }
+        if (energyAdded > 0) {
+            changed();
+        }
+        cir.setReturnValue(energyAdded);
+    }
+
     @Unique
     private long gtocore$sumBatteryEnergy(boolean capacity) {
         long total = 0;
@@ -51,6 +108,20 @@ public abstract class BatteryBufferEnergyTraitMixin extends NotifiableEnergyCont
             } else if (battery instanceof IEnergyStorage energyStorage) {
                 long amount = capacity ? energyStorage.getMaxEnergyStored() : energyStorage.getEnergyStored();
                 total = BatteryBufferMachineAccess.gtocore$addClamped(total, FeCompat.toEu(amount, FeCompat.ratio(false)));
+            }
+        }
+        return total;
+    }
+
+    @Unique
+    private long gtocore$getEnergyCanBeInserted(Iterable<Object> batteries) {
+        long total = 0;
+        for (Object battery : batteries) {
+            if (battery instanceof IElectricItem electricItem) {
+                total = BatteryBufferMachineAccess.gtocore$addClamped(total, electricItem.getMaxCharge() - electricItem.getCharge());
+            } else if (battery instanceof IEnergyStorage energyStorage) {
+                long remaining = energyStorage.getMaxEnergyStored() - energyStorage.getEnergyStored();
+                total = BatteryBufferMachineAccess.gtocore$addClamped(total, FeCompat.toEu(remaining, FeCompat.ratio(false)));
             }
         }
         return total;

--- a/src/main/java/com/gtocore/mixin/gtm/machine/BatteryBufferEnergyTraitMixin.java
+++ b/src/main/java/com/gtocore/mixin/gtm/machine/BatteryBufferEnergyTraitMixin.java
@@ -1,0 +1,58 @@
+package com.gtocore.mixin.gtm.machine;
+
+import com.gregtechceu.gtceu.api.capability.compat.FeCompat;
+import com.gregtechceu.gtceu.api.capability.item.IElectricItem;
+import com.gregtechceu.gtceu.api.machine.MetaMachine;
+import com.gregtechceu.gtceu.api.machine.trait.NotifiableEnergyContainer;
+import com.gregtechceu.gtceu.common.machine.electric.BatteryBufferMachine;
+
+import net.minecraftforge.energy.IEnergyStorage;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(targets = "com.gregtechceu.gtceu.common.machine.electric.BatteryBufferMachine$EnergyBatteryTrait", remap = false)
+public abstract class BatteryBufferEnergyTraitMixin extends NotifiableEnergyContainer {
+
+    @Shadow
+    @Final
+    private BatteryBufferMachine this$0;
+
+    protected BatteryBufferEnergyTraitMixin(MetaMachine machine, long maxCapacity, long maxInputVoltage, long maxInputAmperage, long maxOutputVoltage, long maxOutputAmperage) {
+        super(machine, maxCapacity, maxInputVoltage, maxInputAmperage, maxOutputVoltage, maxOutputAmperage);
+    }
+
+    @Override
+    public long getEnergyCapacity() {
+        return gtocore$sumBatteryEnergy(true);
+    }
+
+    @Inject(method = "getEnergyStored", at = @At("HEAD"), cancellable = true)
+    private void getEnergyStored(CallbackInfoReturnable<Long> cir) {
+        var buffer = (BatteryBufferMachineAccess) this$0;
+        if (buffer.gtocore$checkEnergyStored()) {
+            energyStored = gtocore$sumBatteryEnergy(false);
+            buffer.gtocore$setCheckEnergyStored(false);
+        }
+        cir.setReturnValue(energyStored);
+    }
+
+    @Unique
+    private long gtocore$sumBatteryEnergy(boolean capacity) {
+        long total = 0;
+        for (Object battery : ((BatteryBufferMachineAccess) this$0).gtocore$getAllBatteries()) {
+            if (battery instanceof IElectricItem electricItem) {
+                total = BatteryBufferMachineAccess.gtocore$addClamped(total, capacity ? electricItem.getMaxCharge() : electricItem.getCharge());
+            } else if (battery instanceof IEnergyStorage energyStorage) {
+                long amount = capacity ? energyStorage.getMaxEnergyStored() : energyStorage.getEnergyStored();
+                total = BatteryBufferMachineAccess.gtocore$addClamped(total, FeCompat.toEu(amount, FeCompat.ratio(false)));
+            }
+        }
+        return total;
+    }
+}

--- a/src/main/java/com/gtocore/mixin/gtm/machine/BatteryBufferMachineMixin.java
+++ b/src/main/java/com/gtocore/mixin/gtm/machine/BatteryBufferMachineMixin.java
@@ -1,0 +1,49 @@
+package com.gtocore.mixin.gtm.machine;
+
+import com.gregtechceu.gtceu.common.machine.electric.BatteryBufferMachine;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.List;
+
+@Mixin(BatteryBufferMachine.class)
+public abstract class BatteryBufferMachineMixin implements BatteryBufferMachineAccess {
+
+    @Shadow(remap = false)
+    private List<Object> getAllBatteries() {
+        throw new AssertionError();
+    }
+
+    @Shadow(remap = false)
+    protected boolean checkEnergyStored;
+
+    @Override
+    public List<Object> gtocore$getAllBatteries() {
+        return getAllBatteries();
+    }
+
+    @Override
+    public boolean gtocore$checkEnergyStored() {
+        return checkEnergyStored;
+    }
+
+    @Override
+    public void gtocore$setCheckEnergyStored(boolean checkEnergyStored) {
+        this.checkEnergyStored = checkEnergyStored;
+    }
+}
+
+interface BatteryBufferMachineAccess {
+
+    List<Object> gtocore$getAllBatteries();
+
+    boolean gtocore$checkEnergyStored();
+
+    void gtocore$setCheckEnergyStored(boolean checkEnergyStored);
+
+    static long gtocore$addClamped(long stored, long added) {
+        // ponytail: IEnergyContainer is long-sized; clamp aggregate battery totals here.
+        return added > Long.MAX_VALUE - stored ? Long.MAX_VALUE : stored + added;
+    }
+}

--- a/src/main/java/com/gtocore/mixin/gtm/machine/BatteryBufferMachineMixin.java
+++ b/src/main/java/com/gtocore/mixin/gtm/machine/BatteryBufferMachineMixin.java
@@ -16,11 +16,21 @@ public abstract class BatteryBufferMachineMixin implements BatteryBufferMachineA
     }
 
     @Shadow(remap = false)
+    private List<Object> getNonFullBatteries() {
+        throw new AssertionError();
+    }
+
+    @Shadow(remap = false)
     protected boolean checkEnergyStored;
 
     @Override
     public List<Object> gtocore$getAllBatteries() {
         return getAllBatteries();
+    }
+
+    @Override
+    public List<Object> gtocore$getNonFullBatteries() {
+        return getNonFullBatteries();
     }
 
     @Override
@@ -37,6 +47,8 @@ public abstract class BatteryBufferMachineMixin implements BatteryBufferMachineA
 interface BatteryBufferMachineAccess {
 
     List<Object> gtocore$getAllBatteries();
+
+    List<Object> gtocore$getNonFullBatteries();
 
     boolean gtocore$checkEnergyStored();
 

--- a/src/main/resources/gtocore.mixins.json
+++ b/src/main/resources/gtocore.mixins.json
@@ -164,6 +164,8 @@
     "gtm.item.MaterialPipeBlockItemMixin",
     "gtm.item.TagPrefixItemMixin",
     "gtm.machine.AirScrubberMachineMixin",
+    "gtm.machine.BatteryBufferEnergyTraitMixin",
+    "gtm.machine.BatteryBufferMachineMixin",
     "gtm.machine.CrateMachineMixin",
     "gtm.machine.DataAccessHatchMachineMixin",
     "gtm.machine.EnergyHatchPartMachineMixin",


### PR DESCRIPTION
原逻辑/代码问题：GTCEu 电池箱将内部电池容量/已存电量直接累加到 long；16 个 Long.MAX_VALUE 的 OPV 电池会溢出。上一版把容量和存量分别饱和后，`getEnergyCapacity() - getEnergyStored()` 在“15 满 + 1 空/半空”时仍可能变成 0，导致 wireless cover 不再输入。

修复方式：在 GTOCore mixin 中保留容量/存量饱和聚合，并覆盖 Battery Buffer 输入路径，把可接收空间改为按未满电池的剩余容量逐个累加/饱和，避免两个饱和值相减。导入核验：当前 `libs/gtceu-1.20.1-1.8.0.jar` 只有 `com/gregtechceu/gtceu/api/capability/item/IElectricItem.class`，因此保留该可编译导入。

测试命令和结果：
- `.\gradlew.bat compileJava`：通过（仅有目标内部类需字符串 mixin target 的注解处理器警告）
- `.\gradlew.bat spotlessJavaCheck`：通过
- 临时 `BatteryBufferCapacityCheck.java` 断言：通过，覆盖“15 满 + 1 空/半空”下旧差值为 0、新剩余空间大于 0；临时文件已删除

关联 issue：https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1546
Fixes GregTech-Odyssey/GregTech-Odyssey#1546