### PR TITLE
fix: clamp stocking simulated extracts

### DIFF
--- a/src/main/java/com/gtocore/common/machine/multiblock/part/ae/slots/ExportOnlyAEStockingFluidList.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/part/ae/slots/ExportOnlyAEStockingFluidList.java
@@ -184,7 +184,7 @@ public class ExportOnlyAEStockingFluidList extends ExportOnlyAEFluidList {
                 if (!machine.isOnline()) return 0;
                 var grid = machine.getMainNode().getGrid();
                 if (grid == null) return 0;
-                long extracted = simulate ? stock.amount() : grid.getStorageService().getInventory().extract(stock.what(), amount, Actionable.MODULATE, machine.getActionSource());
+                long extracted = simulate ? Math.min(amount, stock.amount()) : grid.getStorageService().getInventory().extract(stock.what(), amount, Actionable.MODULATE, machine.getActionSource());
                 if (extracted > 0) {
                     if (!simulate) {
                         machine.getThroughputCounter().remove(stock.what(), extracted);

--- a/src/main/java/com/gtocore/common/machine/multiblock/part/ae/slots/ExportOnlyAEStockingItemList.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/part/ae/slots/ExportOnlyAEStockingItemList.java
@@ -179,7 +179,7 @@ public class ExportOnlyAEStockingItemList extends ExportOnlyAEItemList {
                 if (!machine.isOnline()) return 0;
                 var grid = machine.getMainNode().getGrid();
                 if (grid == null) return 0;
-                long extracted = simulate ? stock.amount() : grid.getStorageService().getInventory().extract(stock.what(), amount, Actionable.MODULATE, machine.getActionSource());
+                long extracted = simulate ? Math.min(amount, stock.amount()) : grid.getStorageService().getInventory().extract(stock.what(), amount, Actionable.MODULATE, machine.getActionSource());
                 if (extracted > 0) {
                     if (!simulate) {
                         machine.getThroughputCounter().remove(stock.what(), extracted);


### PR DESCRIPTION
相关问题: https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1459

主要问题是simulate的时候不应该直接给`AE当前库存总量`而是应该和普通的ME输入总线/仓一样给`min(请求数量，当前数量)` 如下

https://github.com/GregTech-Odyssey/GTOCore/blob/cc346441daa7ebe9db260a8359ebeb3ca6096817/src/main/java/com/gtocore/common/machine/multiblock/part/ae/slots/ExportOnlyAEItemSlot.java#L74-L76

但是库存输入直接给了 `stock.amount()` 导致后续结算的时候误将过多的输入进行结算，导致吞输入