### PR TITLE
fix: 渲染白名单

### DIFF
--- a/src/main/java/com/gtocore/config/MixinConfigPlugin.java
+++ b/src/main/java/com/gtocore/config/MixinConfigPlugin.java
@@ -14,6 +14,9 @@ public final class MixinConfigPlugin extends AbstractMixinConfigPlugin {
         if (mixinClassName.equals("com.gtocore.mixin.ae2.search.AEKeyMixin")) {
             return Mods.LANG.isLoaded();
         }
+        if (mixinClassName.equals("com.gtocore.mixin.modernfix.ItemRendererMixin")) {
+            return Mods.MODERNFIX.isLoaded();
+        }
         return true;
     }
 }

--- a/src/main/java/com/gtocore/integration/Mods.java
+++ b/src/main/java/com/gtocore/integration/Mods.java
@@ -23,7 +23,8 @@ public enum Mods {
     JECHARACTERS("jecharacters"),
     LANG("moremorelang"),
     FACTORY_BLOCKS("factory_blocks"),
-    MYTHICBOTANY("mythicbotany");
+    MYTHICBOTANY("mythicbotany"),
+    MODERNFIX("modernfix");
 
     @Getter
     private final boolean loaded;

--- a/src/main/java/com/gtocore/mixin/modernfix/ItemRendererMixin.java
+++ b/src/main/java/com/gtocore/mixin/modernfix/ItemRendererMixin.java
@@ -1,0 +1,29 @@
+package com.gtocore.mixin.modernfix;
+
+import com.gregtechceu.gtceu.api.item.MetaMachineItem;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(value = ItemRenderer.class, priority = 500)
+public class ItemRendererMixin {
+
+    @ModifyArg(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/entity/ItemRenderer;renderModelLists(Lnet/minecraft/client/resources/model/BakedModel;Lnet/minecraft/world/item/ItemStack;IILcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;)V"), index = 0)
+    private BakedModel gto$skipModernFixFastItemRenderingForMetaMachines(BakedModel model, ItemStack stack,
+                                                                         int combinedLight, int combinedOverlay,
+                                                                         PoseStack matrixStack, VertexConsumer buffer,
+                                                                         @Local(ordinal = 0) BakedModel originalModel) {
+        if (stack.getItem() instanceof MetaMachineItem && originalModel != null &&
+                model.getClass().getName().equals("org.embeddedt.modernfix.render.SimpleItemModelView")) {
+            return originalModel;
+        }
+        return model;
+    }
+}

--- a/src/main/resources/gtocore.mixins.json
+++ b/src/main/resources/gtocore.mixins.json
@@ -31,6 +31,7 @@
     "mc.GuiGraphicsMixin",
     "mc.OpenContainerMixin",
     "merequester.NumberFieldMixin",
+    "modernfix.ItemRendererMixin",
     "sodium.SodiumWorldRendererMixin"
   ],
   "mixins": [


### PR DESCRIPTION
ItemRenderer.render(...)
    -> 原版准备调用 renderModelLists(model, stack, ...)

​          -> ModernFix 的 @ModifyArg 先执行
​           条件满足时：
​           model = SimpleItemModelView
​           也就是把原本的 BakedModel 换成 ModernFix 的快速包装模型
​       (**我们加入的部分**)
​          -> GTOCore 的 @ModifyArg 后执行
​           如果 stack 是 MetaMachineItem
​           且当前 model 已经是 SimpleItemModelView：
​           model = originalModel
​           也就是把 ModernFix 的包装撤掉

-> renderModelLists(最终 model, stack, ...)