### PR TITLE
fix: 修复服务器上客户端中 CPU 不显示样板推送状态的问题

### DIFF
--- a/src/main/java/com/gtocore/common/CommonProxy.java
+++ b/src/main/java/com/gtocore/common/CommonProxy.java
@@ -21,6 +21,7 @@ import com.gtocore.eio_travel.implementations.AnchorTravelTarget;
 import com.gtocore.eio_travel.implementations.PatternTravelTarget;
 import com.gtocore.integration.Mods;
 import com.gtocore.integration.ae.PatternContentAccessTerminalMenu;
+import com.gtocore.integration.ae.hooks.IPushResultsHandler;
 import com.gtocore.integration.ae.wtlib.WFTMenu;
 import com.gtocore.integration.ae.wtlib.WRTMenu;
 import com.gtocore.integration.construction_wand.ConstructionWandRegistrar;
@@ -108,6 +109,7 @@ public class CommonProxy {
         GTOCodecs.init();
         GTOCreativeModeTabs.init();
         GTOEntityTypes.init();
+        IPushResultsHandler.init();
         if (!GTCEu.isDataGen() && Mods.FTBQUESTS.isLoaded()) {
             GTOQuestTypes.init();
         }

--- a/src/main/java/com/gtocore/integration/ae/hooks/IPushResultsHandler.java
+++ b/src/main/java/com/gtocore/integration/ae/hooks/IPushResultsHandler.java
@@ -17,6 +17,8 @@ public interface IPushResultsHandler {
         }
     });
 
+    static void init() {}
+
     void gtocore$syncCraftingResults(FriendlyByteBuf buf);
 
     Multimap<AEKey, IPatternProviderLogic.PushResult> gto$getLastCraftingResults();


### PR DESCRIPTION
仅客户端在用到 IPushResultsHandler 的时候不会触发初始化，导致 pushResultUpdate S2C 未注册，在服务器上游玩的客户端不会看到样板推送状态。

不确定这样改好不好，发个 PR