### PR TITLE
refactor: 重构统一样板供应器及样板总成系列命名

### DIFF
--- a/src/generated/resources/assets/gtocore/lang/en_us.json
+++ b/src/generated/resources/assets/gtocore/lang/en_us.json
@@ -1675,6 +1675,7 @@
   "config.gtocore.option.mobConfig": "Mob Settings",
   "config.gtocore.option.naturalRegeneration": "Mob Natural Regeneration",
   "config.gtocore.option.nonCheatEmiInteraction": "Non-Cheat EMI Interaction",
+  "config.gtocore.option.patternContainerNameFormat": "Pattern Container Name Format",
   "config.gtocore.option.recipeCheck": "[Debug] Recipe Conflict Check",
   "config.gtocore.option.renamePatternDefaultString": "Default Value for Rename Pattern",
   "config.gtocore.option.selfRestraint": "Self Restraint Mode",

--- a/src/generated/resources/assets/gtocore/lang/zh_cn.json
+++ b/src/generated/resources/assets/gtocore/lang/zh_cn.json
@@ -1803,6 +1803,7 @@
   "config.gtocore.option.mobConfig": "生物设置",
   "config.gtocore.option.naturalRegeneration": "生物自然回血",
   "config.gtocore.option.nonCheatEmiInteraction": "非作弊时EMI交互",
+  "config.gtocore.option.patternContainerNameFormat": "样板容器名称格式",
   "config.gtocore.option.recipeCheck": "[调试] 配方冲突检查",
   "config.gtocore.option.renamePatternDefaultString": "重命名样板的默认值",
   "config.gtocore.option.selfRestraint": "自我约束模式",

--- a/src/generated/resources/assets/gtocore/lang/zh_tw.json
+++ b/src/generated/resources/assets/gtocore/lang/zh_tw.json
@@ -1803,6 +1803,7 @@
   "config.gtocore.option.mobConfig": "生物設置",
   "config.gtocore.option.naturalRegeneration": "生物自然回血",
   "config.gtocore.option.nonCheatEmiInteraction": "非作弊時EMI交互",
+  "config.gtocore.option.patternContainerNameFormat": "樣板容器名稱格式",
   "config.gtocore.option.recipeCheck": "[調試] 配方衝突檢查",
   "config.gtocore.option.renamePatternDefaultString": "重命名樣板的默認值",
   "config.gtocore.option.selfRestraint": "自我約束模式",

--- a/src/main/java/com/gtocore/common/machine/multiblock/part/ProgrammableHatchPartMachine.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/part/ProgrammableHatchPartMachine.java
@@ -28,6 +28,7 @@ import com.hepdd.gtmthings.api.machine.IProgrammableMachine;
 import com.hepdd.gtmthings.common.item.VirtualItemProviderBehavior;
 import com.hepdd.gtmthings.data.CustomItems;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -133,6 +134,10 @@ public final class ProgrammableHatchPartMachine extends DualHatchPartMachine imp
                 }
             }
         }
+    }
+
+    public @Nullable GTRecipeType getRecipeType() {
+        return recipeType;
     }
 
     @Override

--- a/src/main/java/com/gtocore/common/machine/multiblock/part/ae/MEPatternBufferPartMachine.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/part/ae/MEPatternBufferPartMachine.java
@@ -4,6 +4,7 @@ import com.gtocore.api.gui.configurators.MultiMachineModeFancyConfigurator;
 import com.gtocore.common.data.GTORecipeTypes;
 import com.gtocore.common.data.machines.GTAEMachines;
 import com.gtocore.common.machine.trait.InternalSlotRecipeHandler;
+import com.gtocore.integration.ae.PatternContainerGroupHelper;
 
 import com.gtolib.api.ae2.MyPatternDetailsHelper;
 import com.gtolib.api.annotation.DataGeneratorScanned;
@@ -12,7 +13,6 @@ import com.gtolib.api.machine.trait.NotifiableNotConsumableFluidHandler;
 import com.gtolib.api.machine.trait.NotifiableNotConsumableItemHandler;
 import com.gtolib.api.recipe.RecipeBuilder;
 import com.gtolib.api.recipe.RecipeType;
-import com.gtolib.utils.GTOUtils;
 import com.gtolib.utils.RLUtils;
 
 import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
@@ -20,7 +20,6 @@ import com.gregtechceu.gtceu.api.capability.IWailaDisplayProvider;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.gui.fancy.ConfiguratorPanel;
 import com.gregtechceu.gtceu.api.gui.fancy.TabsWidget;
-import com.gregtechceu.gtceu.api.machine.MultiblockMachineDefinition;
 import com.gregtechceu.gtceu.api.machine.fancyconfigurator.ButtonConfigurator;
 import com.gregtechceu.gtceu.api.machine.fancyconfigurator.CircuitFancyConfigurator;
 import com.gregtechceu.gtceu.api.machine.fancyconfigurator.FancyInvConfigurator;
@@ -50,7 +49,6 @@ import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.*;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -92,7 +90,6 @@ import snownee.jade.api.fluid.JadeFluidObject;
 import snownee.jade.api.ui.IElementHelper;
 
 import java.util.*;
-import java.util.stream.Stream;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -380,32 +377,10 @@ public abstract class MEPatternBufferPartMachine extends MEPatternPartMachineKt<
     public PatternContainerGroup getTerminalGroup() {
         if (isFormed()) {
             IMultiController controller = getController();
-            MultiblockMachineDefinition controllerDefinition = controller.self().getDefinition();
-            GTRecipeType rt = this.recipeType;
-            MutableComponent lidComp = null;
-
-            if (rt == null)
-                rt = controller instanceof IRecipeLogicMachine rlm ? rlm.getRecipeType() : null;
-            if (rt == null || rt == GTORecipeTypes.HATCH_COMBINED) {
-                rt = null;
-                lidComp = (controller instanceof IRecipeLogicMachine rlm ? Stream.of(rlm.getAvailableRecipeTypes()) : Stream.<GTRecipeType>empty())
-                        .map(r -> Component.translatable("gtceu." + r.registryName.getPath()))
-                        .collect(GTOUtils.joiningComponent(Component.literal("/")));
-
-            }
-
-            String lid = rt != null ? rt.registryName.toLanguageKey() : controllerDefinition.getDescriptionId();
-
-            if (!getCustomName().isEmpty()) {
-                return new PatternContainerGroup(AEItemKey.of(controllerDefinition.asStack()), Component.literal(getCustomName()), Collections.emptyList());
-            } else {
-                ItemStack circuitStack = circuitInventorySimulated.storage.getStackInSlot(0);
-                int circuitConfiguration = circuitStack.isEmpty() ? -1 : IntCircuitBehaviour.getCircuitConfiguration(circuitStack);
-                MutableComponent groupName = lidComp != null ? lidComp : Component.translatable(lid);
-                if (circuitConfiguration != -1) groupName = groupName.append(" - " + circuitConfiguration);
-                return new PatternContainerGroup(AEItemKey.of(controllerDefinition.asStack()), groupName,
-                        lidComp != null ? List.of(Component.translatable(lid)) : Collections.emptyList());
-            }
+            Collection<GTRecipeType> availableRecipeTypes = controller instanceof IRecipeLogicMachine recipeMachine ?
+                    Arrays.asList(recipeMachine.getAvailableRecipeTypes()) : List.of();
+            return PatternContainerGroupHelper.forPatternAssembly(
+                    controller.self(), this, getCustomName(), recipeType, availableRecipeTypes);
         } else {
             if (!getCustomName().isEmpty()) {
                 return new PatternContainerGroup(AEItemKey.of(GTAEMachines.ME_PATTERN_BUFFER.asItem()), Component.literal(getCustomName()), Collections.emptyList());

--- a/src/main/java/com/gtocore/common/machine/multiblock/part/ae/MEPatternBufferPartMachine.java
+++ b/src/main/java/com/gtocore/common/machine/multiblock/part/ae/MEPatternBufferPartMachine.java
@@ -391,6 +391,21 @@ public abstract class MEPatternBufferPartMachine extends MEPatternPartMachineKt<
     }
 
     @Override
+    public Component gto$getTerminalGroupSearchName() {
+        if (!isFormed()) {
+            return getTerminalGroup().name();
+        }
+        if (!getCustomName().isEmpty() && !getCustomName().startsWith("+")) {
+            return Component.literal(getCustomName());
+        }
+        IMultiController controller = getController();
+        Collection<GTRecipeType> availableRecipeTypes = controller instanceof IRecipeLogicMachine recipeMachine ?
+                Arrays.asList(recipeMachine.getAvailableRecipeTypes()) : List.of();
+        String extraSuffix = getCustomName().startsWith("+") ? getCustomName().substring(1).strip() : "";
+        return PatternContainerGroupHelper.getSearchName(controller.self(), extraSuffix, recipeType, availableRecipeTypes);
+    }
+
+    @Override
     public void attachConfigurators(ConfiguratorPanel configuratorPanel) {
         this.configuratorPanel = configuratorPanel;
         configuratorPanel.attachConfigurators(new ButtonConfigurator(new GuiTextureGroup(GuiTextures.BUTTON, GuiTextures.REFUND_OVERLAY), this::refundAll).setTooltips(List.of(Component.translatable("gui.gtceu.refund_all.desc"))));

--- a/src/main/java/com/gtocore/common/machine/multiblock/part/ae/MEPatternPartMachineKt.kt
+++ b/src/main/java/com/gtocore/common/machine/multiblock/part/ae/MEPatternPartMachineKt.kt
@@ -279,6 +279,26 @@ abstract class MEPatternPartMachineKt<T : MEPatternPartMachineKt.AbstractInterna
         return PatternContainerGroup(itemKey, description, emptyList())
     }
 
+    override fun `gto$getTerminalGroupSearchName`(): Component {
+        if (!isFormed) {
+            return getTerminalGroup().name()
+        }
+        if (customName.isNotEmpty() && !customName.startsWith("+")) {
+            return Component.literal(customName)
+        }
+
+        val controller = getController()
+        val availableRecipeTypes =
+            if (controller is IRecipeLogicMachine) controller.availableRecipeTypes.asList() else emptyList()
+        val extraSuffix = if (customName.startsWith("+")) customName.substring(1).trim() else ""
+        return PatternContainerGroupHelper.getSearchName(
+            controller.self(),
+            extraSuffix,
+            null,
+            availableRecipeTypes,
+        )
+    }
+
     // ==================== 其他接口实现 ====================
     override fun getGrid(): IGrid? = mainNode.grid
 

--- a/src/main/java/com/gtocore/common/machine/multiblock/part/ae/MEPatternPartMachineKt.kt
+++ b/src/main/java/com/gtocore/common/machine/multiblock/part/ae/MEPatternPartMachineKt.kt
@@ -4,6 +4,7 @@ import com.gtocore.common.data.machines.GTAEMachines
 import com.gtocore.common.machine.multiblock.part.ae.widget.slot.AEPatternViewSlotWidgetKt
 import com.gtocore.eio_travel.logic.TravelSavedData
 import com.gtocore.eio_travel.logic.TravelUtils
+import com.gtocore.integration.ae.PatternContainerGroupHelper
 import com.gtocore.integration.ae.hooks.IExtendedPatternContainer
 import com.gtocore.integration.ae.wireless.WirelessMachine
 
@@ -13,7 +14,6 @@ import net.minecraft.nbt.CompoundTag
 import net.minecraft.nbt.ListTag
 import net.minecraft.nbt.Tag
 import net.minecraft.network.chat.Component
-import net.minecraft.network.chat.MutableComponent
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.world.InteractionHand
 import net.minecraft.world.InteractionResult
@@ -42,8 +42,8 @@ import com.gregtechceu.gtceu.api.gui.fancy.IFancyConfiguratorButton
 import com.gregtechceu.gtceu.api.machine.TickableSubscription
 import com.gregtechceu.gtceu.api.machine.feature.IDropSaveMachine
 import com.gregtechceu.gtceu.api.machine.feature.IInteractedMachine
+import com.gregtechceu.gtceu.api.machine.feature.IRecipeLogicMachine
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController
-import com.gregtechceu.gtceu.api.recipe.GTRecipeType
 import com.gregtechceu.gtceu.api.recipe.handler.IO
 import com.gregtechceu.gtceu.api.recipe.handler.RecipeHandlerUnit
 import com.gregtechceu.gtceu.api.transfer.item.CustomItemStackHandler
@@ -57,7 +57,6 @@ import com.gtolib.api.ae2.pattern.IParallelPatternDetails
 import com.gtolib.api.annotation.DataGeneratorScanned
 import com.gtolib.api.annotation.language.RegisterLanguage
 import com.gtolib.api.gui.ktflexible.*
-import com.gtolib.api.machine.feature.IEnhancedRecipeLogicMachine
 import com.lowdragmc.lowdraglib.gui.texture.GuiTextureGroup
 import com.lowdragmc.lowdraglib.gui.util.ClickData
 import com.lowdragmc.lowdraglib.gui.widget.Widget
@@ -65,9 +64,7 @@ import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup
 import com.lowdragmc.lowdraglib.syncdata.IContentChangeAware
 import com.lowdragmc.lowdraglib.syncdata.ITagSerializable
 
-import java.util.function.BiConsumer
 import java.util.function.IntSupplier
-import java.util.stream.Stream
 import javax.annotation.ParametersAreNonnullByDefault
 
 @ParametersAreNonnullByDefault
@@ -256,44 +253,17 @@ abstract class MEPatternPartMachineKt<T : MEPatternPartMachineKt.AbstractInterna
         val (itemKey, description) = when {
             isFormed -> {
                 val controller = getController()
-                val controllerDefinition = controller.self().definition
-                AEItemKey.of(controllerDefinition.asStack()) to
-                    if (customName.isNotEmpty()) {
-                        Component.literal(customName)
-                    } else {
-                        Component.translatable(controllerDefinition.descriptionId)
-                            .append("-")
-                            .append(
-                                (
-                                    if (controller is IEnhancedRecipeLogicMachine) {
-                                        Stream.of(
-                                            *controller.availableRecipeTypes,
-                                        )
-                                            .map { r: GTRecipeType? -> Component.translatable("gtceu." + r!!.registryName.path) }
-                                            .collect(
-                                                { Component.empty() },
-                                                BiConsumer { c: MutableComponent?, t: MutableComponent? ->
-                                                    c!!.append(
-                                                        (if (c.string.isEmpty()) t else Component.literal("/").append(t as Component)) as Component,
-                                                    )
-                                                },
-                                                { c1: MutableComponent?, c2: MutableComponent? ->
-                                                    c1!!.append(
-                                                        if (c2!!.string.isEmpty()) {
-                                                            c2
-                                                        } else {
-                                                            Component.literal("/")
-                                                                .append(c2)
-                                                        },
-                                                    )
-                                                },
-                                            )
-                                    } else {
-                                        Component.empty()
-                                    }
-                                    ),
-                            )
-                    }
+                val availableRecipeTypes =
+                    if (controller is IRecipeLogicMachine) controller.availableRecipeTypes.asList() else emptyList()
+                val group =
+                    PatternContainerGroupHelper.forPatternAssembly(
+                        controller.self(),
+                        this,
+                        customName,
+                        null,
+                        availableRecipeTypes,
+                    )
+                group.icon() to group.name()
             }
 
             else -> {

--- a/src/main/java/com/gtocore/common/machine/multiblock/part/ae/MEPatternPartMachineKt.kt
+++ b/src/main/java/com/gtocore/common/machine/multiblock/part/ae/MEPatternPartMachineKt.kt
@@ -250,33 +250,31 @@ abstract class MEPatternPartMachineKt<T : MEPatternPartMachineKt.AbstractInterna
     override fun getTerminalPatternInventory(): InternalInventory = internalPatternInventory
 
     override fun getTerminalGroup(): PatternContainerGroup {
-        val (itemKey, description) = when {
+        return when {
             isFormed -> {
                 val controller = getController()
                 val availableRecipeTypes =
                     if (controller is IRecipeLogicMachine) controller.availableRecipeTypes.asList() else emptyList()
-                val group =
-                    PatternContainerGroupHelper.forPatternAssembly(
-                        controller.self(),
-                        this,
-                        customName,
-                        null,
-                        availableRecipeTypes,
-                    )
-                group.icon() to group.name()
+                PatternContainerGroupHelper.forPatternAssembly(
+                    controller.self(),
+                    this,
+                    customName,
+                    null,
+                    availableRecipeTypes,
+                )
             }
 
             else -> {
-                AEItemKey.of(GTAEMachines.ME_PATTERN_BUFFER.asItem()) to
+                val itemKey = AEItemKey.of(GTAEMachines.ME_PATTERN_BUFFER.asItem())
+                val description =
                     if (customName.isNotEmpty()) {
                         Component.literal(customName)
                     } else {
                         GTAEMachines.ME_PATTERN_BUFFER.get().definition.asItem().description
                     }
+                PatternContainerGroup(itemKey, description, emptyList())
             }
         }
-
-        return PatternContainerGroup(itemKey, description, emptyList())
     }
 
     override fun `gto$getTerminalGroupSearchName`(): Component {

--- a/src/main/java/com/gtocore/config/GTOConfig.java
+++ b/src/main/java/com/gtocore/config/GTOConfig.java
@@ -335,15 +335,6 @@ public final class GTOConfig {
         public boolean craftingJobFinishedNotification = true;
 
         @Configurable
-        @Configurable.Comment({
-                "样板供应器/样板总成显示名称格式。可用占位符：%m 机器名，%t 等级，%s 自定义后缀，%r 配方类型（仅多配方类型机器），%R 配方类型（始终显示）。移除占位符即可隐藏对应部分。",
-                "Pattern Provider/Pattern Assembly display name format. Placeholders: %m machine name, %t tier, %s custom suffix, %r recipe type (multi-recipe machines only), %R recipe type (always). Remove a placeholder to hide that part."
-        })
-        @RegisterLanguage(namePrefix = "config.gtocore.option", en = "Pattern Container Name Format", cn = "样板容器名称格式")
-        @Configurable.Gui.CharacterLimit(256)
-        public String patternContainerNameFormat = "%m %t %s %r";
-
-        @Configurable
         @RegisterLanguage(namePrefix = "config.gtocore.option", en = "HUD Settings", cn = "HUD 设置")
         public HUDConfig hud = new HUDConfig();
 
@@ -443,6 +434,15 @@ public final class GTOConfig {
         @Configurable.Comment({ "启用后，进入游戏时，若多方块结构未能成型，则将错误信息将发送给机器的所有者", "When enabled, if the multiblock structure fails to form when entering the game, the error message will be sent to the owner of the machine" })
         @RegisterLanguage(namePrefix = "config.gtocore.option", en = "Send Multiblock Error Messages", cn = "发送多方块错误信息")
         public boolean sendMultiblockErrorMessages = true;
+
+        @Configurable
+        @Configurable.Comment({
+                "样板供应器/样板总成显示名称格式。可用占位符：%m 机器名，%t 等级，%s 自定义后缀，%r 配方类型（仅多配方类型机器），%R 配方类型（始终显示）。移除占位符即可隐藏对应部分。",
+                "Pattern Provider/Pattern Assembly display name format. Placeholders: %m machine name, %t tier, %s custom suffix, %r recipe type (multi-recipe machines only), %R recipe type (always). Remove a placeholder to hide that part."
+        })
+        @RegisterLanguage(namePrefix = "config.gtocore.option", en = "Pattern Container Name Format", cn = "样板容器名称格式")
+        @Configurable.Gui.CharacterLimit(256)
+        public String patternContainerNameFormat = "%m %t %s %r";
 
         @Configurable
         @Configurable.Comment({ "一些机器内容会以服务器语言的翻译呈现", "Some machine contents will be presented in the server language translation" })

--- a/src/main/java/com/gtocore/config/GTOConfig.java
+++ b/src/main/java/com/gtocore/config/GTOConfig.java
@@ -335,6 +335,15 @@ public final class GTOConfig {
         public boolean craftingJobFinishedNotification = true;
 
         @Configurable
+        @Configurable.Comment({
+                "样板供应器/样板总成显示名称格式。可用占位符：%m 机器名，%t 等级，%s 自定义后缀，%r 配方类型（仅多配方类型机器），%R 配方类型（始终显示）。移除占位符即可隐藏对应部分。",
+                "Pattern Provider/Pattern Assembly display name format. Placeholders: %m machine name, %t tier, %s custom suffix, %r recipe type (multi-recipe machines only), %R recipe type (always). Remove a placeholder to hide that part."
+        })
+        @RegisterLanguage(namePrefix = "config.gtocore.option", en = "Pattern Container Name Format", cn = "样板容器名称格式")
+        @Configurable.Gui.CharacterLimit(256)
+        public String patternContainerNameFormat = "%m %t %s %r";
+
+        @Configurable
         @RegisterLanguage(namePrefix = "config.gtocore.option", en = "HUD Settings", cn = "HUD 设置")
         public HUDConfig hud = new HUDConfig();
 

--- a/src/main/java/com/gtocore/integration/ae/PatternContainerGroupHelper.java
+++ b/src/main/java/com/gtocore/integration/ae/PatternContainerGroupHelper.java
@@ -33,6 +33,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 
 public final class PatternContainerGroupHelper {
 
@@ -101,9 +102,10 @@ public final class PatternContainerGroupHelper {
                                                      boolean showAllRecipeTypes,
                                                      List<Component> tooltip) {
         MutableComponent name = getMachineName(displayMachine);
+        Component recipeTypeName = getRecipeTypeName(name, selectedRecipeType, availableRecipeTypes, showAllRecipeTypes);
         appendField(name, getMachineTier(displayMachine));
         appendField(name, extraSuffix.isBlank() ? null : Component.literal(extraSuffix.strip()));
-        appendField(name, getRecipeTypeName(selectedRecipeType, availableRecipeTypes, showAllRecipeTypes));
+        appendField(name, recipeTypeName);
         return new PatternContainerGroup(AEItemKey.of(displayMachine.getDefinition().asStack()), name, tooltip);
     }
 
@@ -155,32 +157,45 @@ public final class PatternContainerGroupHelper {
         return tierCasingMachine.getCasingTier(GTORecipeDataKeys.INTEGRAL_FRAMEWORK_TIER);
     }
 
-    private static @Nullable Component getRecipeTypeName(@Nullable GTRecipeType selectedRecipeType,
+    private static @Nullable Component getRecipeTypeName(Component machineName,
+                                                         @Nullable GTRecipeType selectedRecipeType,
                                                          Collection<GTRecipeType> availableRecipeTypes,
                                                          boolean showAllRecipeTypes) {
-        long displayableRecipeTypeCount = availableRecipeTypes.stream()
+        List<GTRecipeType> displayableRecipeTypes = availableRecipeTypes.stream()
                 .filter(PatternContainerGroupHelper::isDisplayableRecipeType)
-                .count();
-        if (displayableRecipeTypeCount <= 1) {
+                .toList();
+        if (displayableRecipeTypes.size() == 1) {
+            GTRecipeType recipeType = displayableRecipeTypes.get(0);
+            Component recipeTypeName = getRecipeTypeDisplayName(recipeType);
+            return containsText(machineName, recipeTypeName) ? null : recipeTypeName;
+        }
+        if (displayableRecipeTypes.isEmpty()) {
             return null;
         }
 
         if (!showAllRecipeTypes) {
             return isDisplayableRecipeType(selectedRecipeType) ?
-                    Component.translatable(selectedRecipeType.registryName.toLanguageKey()) : null;
+                    getRecipeTypeDisplayName(selectedRecipeType) : null;
         }
 
         MutableComponent result = Component.empty();
-        for (GTRecipeType recipeType : availableRecipeTypes) {
-            if (!isDisplayableRecipeType(recipeType)) {
-                continue;
-            }
+        for (GTRecipeType recipeType : displayableRecipeTypes) {
             if (!result.getString().isEmpty()) {
                 result.append("/");
             }
-            result.append(Component.translatable(recipeType.registryName.toLanguageKey()));
+            result.append(getRecipeTypeDisplayName(recipeType));
         }
         return result.getString().isEmpty() ? null : result;
+    }
+
+    private static Component getRecipeTypeDisplayName(GTRecipeType recipeType) {
+        return Component.translatable(recipeType.registryName.toLanguageKey());
+    }
+
+    private static boolean containsText(Component container, Component content) {
+        String containerText = container.getString().strip().toLowerCase(Locale.ROOT);
+        String contentText = content.getString().strip().toLowerCase(Locale.ROOT);
+        return !contentText.isEmpty() && containerText.contains(contentText);
     }
 
     private static boolean isDisplayableRecipeType(@Nullable GTRecipeType recipeType) {

--- a/src/main/java/com/gtocore/integration/ae/PatternContainerGroupHelper.java
+++ b/src/main/java/com/gtocore/integration/ae/PatternContainerGroupHelper.java
@@ -81,7 +81,7 @@ public final class PatternContainerGroupHelper {
                                                      List<Component> tooltip) {
         NameParts parts = getNameParts(displayMachine, extraSuffix, selectedRecipeType, availableRecipeTypes,
                 showAllRecipeTypes);
-        MutableComponent name = formatName(parts, GTOConfig.INSTANCE.client.patternContainerNameFormat);
+        MutableComponent name = formatName(parts, GTOConfig.INSTANCE.misc.patternContainerNameFormat);
         return new PatternContainerGroup(AEItemKey.of(displayMachine.getDefinition().asStack()), name, tooltip);
     }
 

--- a/src/main/java/com/gtocore/integration/ae/PatternContainerGroupHelper.java
+++ b/src/main/java/com/gtocore/integration/ae/PatternContainerGroupHelper.java
@@ -1,0 +1,204 @@
+package com.gtocore.integration.ae;
+
+import com.gtocore.common.data.GTORecipeDataKeys;
+import com.gtocore.common.data.GTORecipeTypes;
+import com.gtocore.common.machine.multiblock.electric.processing.ProcessingPlantMachine;
+import com.gtocore.common.machine.multiblock.part.ProgrammableHatchPartMachine;
+
+import com.gtolib.api.machine.feature.multiblock.ITierCasingMachine;
+
+import com.gregtechceu.gtceu.api.GTValues;
+import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
+import com.gregtechceu.gtceu.api.item.MetaMachineItem;
+import com.gregtechceu.gtceu.api.machine.MetaMachine;
+import com.gregtechceu.gtceu.api.machine.feature.IOverclockMachine;
+import com.gregtechceu.gtceu.api.machine.feature.IRecipeLogicMachine;
+import com.gregtechceu.gtceu.api.machine.feature.ITieredMachine;
+import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
+import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiPart;
+import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
+import com.gregtechceu.gtceu.utils.GTUtil;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+
+import appeng.api.implementations.blockentities.PatternContainerGroup;
+import appeng.api.stacks.AEItemKey;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+public final class PatternContainerGroupHelper {
+
+    private PatternContainerGroupHelper() {}
+
+    public static @Nullable PatternContainerGroup fromMachine(Level level, BlockPos pos, String extraSuffix) {
+        if (!(level.getBlockEntity(pos) instanceof MetaMachineBlockEntity blockEntity)) {
+            return null;
+        }
+
+        MetaMachine machine = blockEntity.getMetaMachine();
+        if (machine == null) {
+            return null;
+        }
+
+        MetaMachine displayMachine = machine;
+        IRecipeLogicMachine recipeMachine = machine instanceof IRecipeLogicMachine logicMachine ? logicMachine : null;
+        GTRecipeType selectedRecipeType = getCurrentRecipeType(recipeMachine);
+        boolean showAllRecipeTypes = false;
+        List<Component> tooltip = List.of();
+
+        if (machine instanceof IMultiPart partMachine) {
+            IMultiController controller = partMachine.getController();
+            if (controller != null) {
+                displayMachine = controller.self();
+                recipeMachine = controller instanceof IRecipeLogicMachine logicMachine ? logicMachine : null;
+                tooltip = List.of(Component.translatable(machine.getDefinition().getDescriptionId()));
+
+                if (machine instanceof ProgrammableHatchPartMachine programmableHatch) {
+                    selectedRecipeType = programmableHatch.getRecipeType();
+                    showAllRecipeTypes = selectedRecipeType == null ||
+                            selectedRecipeType == GTORecipeTypes.HATCH_COMBINED;
+                } else {
+                    selectedRecipeType = getCurrentRecipeType(recipeMachine);
+                }
+            }
+        }
+
+        Collection<GTRecipeType> availableRecipeTypes = recipeMachine == null ?
+                List.of() : Arrays.asList(recipeMachine.getAvailableRecipeTypes());
+        return createGroup(displayMachine, extraSuffix, selectedRecipeType, availableRecipeTypes,
+                showAllRecipeTypes, tooltip);
+    }
+
+    public static PatternContainerGroup forPatternAssembly(MetaMachine displayMachine, MetaMachine actualMachine,
+                                                           String customName,
+                                                           @Nullable GTRecipeType selectedRecipeType,
+                                                           Collection<GTRecipeType> availableRecipeTypes) {
+        var icon = AEItemKey.of(displayMachine.getDefinition().asStack());
+        List<Component> tooltip = List.of(
+                Component.translatable(actualMachine.getDefinition().getDescriptionId()));
+        if (!customName.isEmpty() && !customName.startsWith("+")) {
+            return new PatternContainerGroup(icon, Component.literal(customName), tooltip);
+        }
+
+        String extraSuffix = customName.startsWith("+") ? customName.substring(1).strip() : "";
+        boolean showAllRecipeTypes = selectedRecipeType == null ||
+                selectedRecipeType == GTORecipeTypes.HATCH_COMBINED;
+        return createGroup(displayMachine, extraSuffix, selectedRecipeType, availableRecipeTypes,
+                showAllRecipeTypes, tooltip);
+    }
+
+    private static PatternContainerGroup createGroup(MetaMachine displayMachine, String extraSuffix,
+                                                     @Nullable GTRecipeType selectedRecipeType,
+                                                     Collection<GTRecipeType> availableRecipeTypes,
+                                                     boolean showAllRecipeTypes,
+                                                     List<Component> tooltip) {
+        MutableComponent name = getMachineName(displayMachine);
+        appendField(name, getMachineTier(displayMachine));
+        appendField(name, extraSuffix.isBlank() ? null : Component.literal(extraSuffix.strip()));
+        appendField(name, getRecipeTypeName(selectedRecipeType, availableRecipeTypes, showAllRecipeTypes));
+        return new PatternContainerGroup(AEItemKey.of(displayMachine.getDefinition().asStack()), name, tooltip);
+    }
+
+    private static MutableComponent getMachineName(MetaMachine machine) {
+        var title = Component.translatable(machine.getDefinition().getDescriptionId());
+        if (machine instanceof ProcessingPlantMachine processingPlantMachine) {
+            ItemStack stack = processingPlantMachine.getMachineStorage().getStackInSlot(0);
+            if (stack.getItem() instanceof MetaMachineItem metaMachineItem) {
+                return title.copy()
+                        .append(" - ")
+                        .append(Component.translatable(metaMachineItem.getDefinition().getDescriptionId()));
+            }
+        }
+        return title;
+    }
+
+    private static @Nullable Component getMachineTier(MetaMachine machine) {
+        Integer tier = getMachineRecipeTier(machine);
+        if (tier == null) {
+            return null;
+        }
+        if (tier >= 0 && tier < GTValues.TIER_COUNT) {
+            return Component.literal(GTValues.VNF[tier])
+                    .withStyle(style -> style.withColor(GTValues.VC[tier]));
+        }
+        return Component.literal("MAX");
+    }
+
+    private static @Nullable Integer getMachineRecipeTier(MetaMachine machine) {
+        if (machine instanceof ITieredMachine tieredMachine && tieredMachine.getTier() >= GTValues.ULV) {
+            return tieredMachine.getTier();
+        }
+        if (machine instanceof IOverclockMachine overclockMachine &&
+                overclockMachine.getMaxOverclockTier() >= GTValues.ULV) {
+            return overclockMachine.getMaxOverclockTier();
+        }
+        if (machine instanceof IOverclockMachine overclockMachine) {
+            long voltage = overclockMachine.getOverclockVoltage();
+            if (voltage > 0) {
+                return (int) GTUtil.getFloorTierByVoltage(voltage);
+            }
+        }
+        if (machine instanceof ProcessingPlantMachine || !(machine instanceof ITierCasingMachine tierCasingMachine)) {
+            return null;
+        }
+        if (!tierCasingMachine.getCasingTiers().containsKey(GTORecipeDataKeys.INTEGRAL_FRAMEWORK_TIER)) {
+            return null;
+        }
+        return tierCasingMachine.getCasingTier(GTORecipeDataKeys.INTEGRAL_FRAMEWORK_TIER);
+    }
+
+    private static @Nullable Component getRecipeTypeName(@Nullable GTRecipeType selectedRecipeType,
+                                                         Collection<GTRecipeType> availableRecipeTypes,
+                                                         boolean showAllRecipeTypes) {
+        long displayableRecipeTypeCount = availableRecipeTypes.stream()
+                .filter(PatternContainerGroupHelper::isDisplayableRecipeType)
+                .count();
+        if (displayableRecipeTypeCount <= 1) {
+            return null;
+        }
+
+        if (!showAllRecipeTypes) {
+            return isDisplayableRecipeType(selectedRecipeType) ?
+                    Component.translatable(selectedRecipeType.registryName.toLanguageKey()) : null;
+        }
+
+        MutableComponent result = Component.empty();
+        for (GTRecipeType recipeType : availableRecipeTypes) {
+            if (!isDisplayableRecipeType(recipeType)) {
+                continue;
+            }
+            if (!result.getString().isEmpty()) {
+                result.append("/");
+            }
+            result.append(Component.translatable(recipeType.registryName.toLanguageKey()));
+        }
+        return result.getString().isEmpty() ? null : result;
+    }
+
+    private static boolean isDisplayableRecipeType(@Nullable GTRecipeType recipeType) {
+        return recipeType != null &&
+                recipeType != GTORecipeTypes.DUMMY_RECIPES &&
+                recipeType != GTORecipeTypes.HATCH_COMBINED;
+    }
+
+    private static @Nullable GTRecipeType getCurrentRecipeType(@Nullable IRecipeLogicMachine recipeMachine) {
+        if (recipeMachine == null || recipeMachine.getAvailableRecipeTypes().length == 0) {
+            return null;
+        }
+        return recipeMachine.getRecipeType();
+    }
+
+    private static void appendField(MutableComponent target, @Nullable Component field) {
+        if (field != null && !field.getString().isBlank()) {
+            target.append(" ").append(field);
+        }
+    }
+}

--- a/src/main/java/com/gtocore/integration/ae/PatternContainerGroupHelper.java
+++ b/src/main/java/com/gtocore/integration/ae/PatternContainerGroupHelper.java
@@ -4,6 +4,7 @@ import com.gtocore.common.data.GTORecipeDataKeys;
 import com.gtocore.common.data.GTORecipeTypes;
 import com.gtocore.common.machine.multiblock.electric.processing.ProcessingPlantMachine;
 import com.gtocore.common.machine.multiblock.part.ProgrammableHatchPartMachine;
+import com.gtocore.config.GTOConfig;
 
 import com.gtolib.api.machine.feature.multiblock.ITierCasingMachine;
 
@@ -33,49 +34,26 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 
 public final class PatternContainerGroupHelper {
+
+    private static final char MACHINE_PLACEHOLDER = 'm';
+    private static final char TIER_PLACEHOLDER = 't';
+    private static final char SUFFIX_PLACEHOLDER = 's';
+    private static final char RECIPE_TYPE_MULTI_PLACEHOLDER = 'r';
+    private static final char RECIPE_TYPE_ALWAYS_PLACEHOLDER = 'R';
+    private static final String SEARCH_NAME_FORMAT = "%m %t %s %R";
 
     private PatternContainerGroupHelper() {}
 
     public static @Nullable PatternContainerGroup fromMachine(Level level, BlockPos pos, String extraSuffix) {
-        if (!(level.getBlockEntity(pos) instanceof MetaMachineBlockEntity blockEntity)) {
+        MachineNameContext context = getMachineNameContext(level, pos);
+        if (context == null) {
             return null;
         }
 
-        MetaMachine machine = blockEntity.getMetaMachine();
-        if (machine == null) {
-            return null;
-        }
-
-        MetaMachine displayMachine = machine;
-        IRecipeLogicMachine recipeMachine = machine instanceof IRecipeLogicMachine logicMachine ? logicMachine : null;
-        GTRecipeType selectedRecipeType = getCurrentRecipeType(recipeMachine);
-        boolean showAllRecipeTypes = false;
-        List<Component> tooltip = List.of();
-
-        if (machine instanceof IMultiPart partMachine) {
-            IMultiController controller = partMachine.getController();
-            if (controller != null) {
-                displayMachine = controller.self();
-                recipeMachine = controller instanceof IRecipeLogicMachine logicMachine ? logicMachine : null;
-                tooltip = List.of(Component.translatable(machine.getDefinition().getDescriptionId()));
-
-                if (machine instanceof ProgrammableHatchPartMachine programmableHatch) {
-                    selectedRecipeType = programmableHatch.getRecipeType();
-                    showAllRecipeTypes = selectedRecipeType == null ||
-                            selectedRecipeType == GTORecipeTypes.HATCH_COMBINED;
-                } else {
-                    selectedRecipeType = getCurrentRecipeType(recipeMachine);
-                }
-            }
-        }
-
-        Collection<GTRecipeType> availableRecipeTypes = recipeMachine == null ?
-                List.of() : Arrays.asList(recipeMachine.getAvailableRecipeTypes());
-        return createGroup(displayMachine, extraSuffix, selectedRecipeType, availableRecipeTypes,
-                showAllRecipeTypes, tooltip);
+        return createGroup(context.displayMachine(), extraSuffix, context.selectedRecipeType(),
+                getAvailableRecipeTypes(context.recipeMachine()), context.showAllRecipeTypes(), context.tooltip());
     }
 
     public static PatternContainerGroup forPatternAssembly(MetaMachine displayMachine, MetaMachine actualMachine,
@@ -101,12 +79,78 @@ public final class PatternContainerGroupHelper {
                                                      Collection<GTRecipeType> availableRecipeTypes,
                                                      boolean showAllRecipeTypes,
                                                      List<Component> tooltip) {
-        MutableComponent name = getMachineName(displayMachine);
-        Component recipeTypeName = getRecipeTypeName(name, selectedRecipeType, availableRecipeTypes, showAllRecipeTypes);
-        appendField(name, getMachineTier(displayMachine));
-        appendField(name, extraSuffix.isBlank() ? null : Component.literal(extraSuffix.strip()));
-        appendField(name, recipeTypeName);
+        NameParts parts = getNameParts(displayMachine, extraSuffix, selectedRecipeType, availableRecipeTypes,
+                showAllRecipeTypes);
+        MutableComponent name = formatName(parts, GTOConfig.INSTANCE.client.patternContainerNameFormat);
         return new PatternContainerGroup(AEItemKey.of(displayMachine.getDefinition().asStack()), name, tooltip);
+    }
+
+    public static Component getSearchName(MetaMachine displayMachine, String extraSuffix,
+                                          @Nullable GTRecipeType selectedRecipeType,
+                                          Collection<GTRecipeType> availableRecipeTypes) {
+        return formatName(getNameParts(displayMachine, extraSuffix, selectedRecipeType, availableRecipeTypes,
+                selectedRecipeType == null || selectedRecipeType == GTORecipeTypes.HATCH_COMBINED), SEARCH_NAME_FORMAT);
+    }
+
+    public static @Nullable Component getSearchName(Level level, BlockPos pos, String extraSuffix) {
+        MachineNameContext context = getMachineNameContext(level, pos);
+        if (context == null) {
+            return null;
+        }
+
+        return formatName(getNameParts(context.displayMachine(), extraSuffix, context.selectedRecipeType(),
+                getAvailableRecipeTypes(context.recipeMachine()), context.showAllRecipeTypes()), SEARCH_NAME_FORMAT);
+    }
+
+    private static @Nullable MachineNameContext getMachineNameContext(Level level, BlockPos pos) {
+        if (!(level.getBlockEntity(pos) instanceof MetaMachineBlockEntity blockEntity)) {
+            return null;
+        }
+
+        MetaMachine machine = blockEntity.getMetaMachine();
+        if (machine == null) {
+            return null;
+        }
+
+        MetaMachine displayMachine = machine;
+        IRecipeLogicMachine recipeMachine = machine instanceof IRecipeLogicMachine logicMachine ? logicMachine : null;
+        GTRecipeType selectedRecipeType = getCurrentRecipeType(recipeMachine);
+        boolean showAllRecipeTypes = false;
+        List<Component> tooltip = List.of();
+
+        if (machine instanceof IMultiPart partMachine) {
+            IMultiController controller = partMachine.getController();
+            if (controller != null) {
+                displayMachine = controller.self();
+                recipeMachine = controller instanceof IRecipeLogicMachine logicMachine ? logicMachine : null;
+                tooltip = List.of(Component.translatable(machine.getDefinition().getDescriptionId()));
+                if (machine instanceof ProgrammableHatchPartMachine programmableHatch) {
+                    selectedRecipeType = programmableHatch.getRecipeType();
+                    showAllRecipeTypes = selectedRecipeType == null ||
+                            selectedRecipeType == GTORecipeTypes.HATCH_COMBINED;
+                } else {
+                    selectedRecipeType = getCurrentRecipeType(recipeMachine);
+                }
+            }
+        }
+
+        return new MachineNameContext(displayMachine, recipeMachine, selectedRecipeType, showAllRecipeTypes, tooltip);
+    }
+
+    private static Collection<GTRecipeType> getAvailableRecipeTypes(@Nullable IRecipeLogicMachine recipeMachine) {
+        return recipeMachine == null ? List.of() : Arrays.asList(recipeMachine.getAvailableRecipeTypes());
+    }
+
+    private static NameParts getNameParts(MetaMachine displayMachine, String extraSuffix,
+                                          @Nullable GTRecipeType selectedRecipeType,
+                                          Collection<GTRecipeType> availableRecipeTypes,
+                                          boolean showAllRecipeTypes) {
+        return new NameParts(
+                getMachineName(displayMachine),
+                getMachineTier(displayMachine),
+                extraSuffix.isBlank() ? null : Component.literal(extraSuffix.strip()),
+                getRecipeTypeName(selectedRecipeType, availableRecipeTypes, showAllRecipeTypes),
+                hasMultipleDisplayableRecipeTypes(availableRecipeTypes));
     }
 
     private static MutableComponent getMachineName(MetaMachine machine) {
@@ -157,20 +201,17 @@ public final class PatternContainerGroupHelper {
         return tierCasingMachine.getCasingTier(GTORecipeDataKeys.INTEGRAL_FRAMEWORK_TIER);
     }
 
-    private static @Nullable Component getRecipeTypeName(Component machineName,
-                                                         @Nullable GTRecipeType selectedRecipeType,
+    private static @Nullable Component getRecipeTypeName(@Nullable GTRecipeType selectedRecipeType,
                                                          Collection<GTRecipeType> availableRecipeTypes,
                                                          boolean showAllRecipeTypes) {
         List<GTRecipeType> displayableRecipeTypes = availableRecipeTypes.stream()
                 .filter(PatternContainerGroupHelper::isDisplayableRecipeType)
                 .toList();
-        if (displayableRecipeTypes.size() == 1) {
-            GTRecipeType recipeType = displayableRecipeTypes.get(0);
-            Component recipeTypeName = getRecipeTypeDisplayName(recipeType);
-            return containsText(machineName, recipeTypeName) ? null : recipeTypeName;
-        }
         if (displayableRecipeTypes.isEmpty()) {
             return null;
+        }
+        if (displayableRecipeTypes.size() == 1) {
+            return getRecipeTypeDisplayName(displayableRecipeTypes.get(0));
         }
 
         if (!showAllRecipeTypes) {
@@ -188,14 +229,15 @@ public final class PatternContainerGroupHelper {
         return result.getString().isEmpty() ? null : result;
     }
 
-    private static Component getRecipeTypeDisplayName(GTRecipeType recipeType) {
-        return Component.translatable(recipeType.registryName.toLanguageKey());
+    private static boolean hasMultipleDisplayableRecipeTypes(Collection<GTRecipeType> availableRecipeTypes) {
+        return availableRecipeTypes.stream()
+                .filter(PatternContainerGroupHelper::isDisplayableRecipeType)
+                .limit(2)
+                .count() > 1;
     }
 
-    private static boolean containsText(Component container, Component content) {
-        String containerText = container.getString().strip().toLowerCase(Locale.ROOT);
-        String contentText = content.getString().strip().toLowerCase(Locale.ROOT);
-        return !contentText.isEmpty() && containerText.contains(contentText);
+    private static Component getRecipeTypeDisplayName(GTRecipeType recipeType) {
+        return Component.translatable(recipeType.registryName.toLanguageKey());
     }
 
     private static boolean isDisplayableRecipeType(@Nullable GTRecipeType recipeType) {
@@ -211,9 +253,103 @@ public final class PatternContainerGroupHelper {
         return recipeMachine.getRecipeType();
     }
 
-    private static void appendField(MutableComponent target, @Nullable Component field) {
-        if (field != null && !field.getString().isBlank()) {
-            target.append(" ").append(field);
+    private static MutableComponent formatName(NameParts parts, String format) {
+        if (format == null || format.isBlank()) {
+            format = "%m";
         }
+
+        MutableComponent result = Component.empty();
+        StringBuilder literal = new StringBuilder();
+        boolean appended = false;
+        boolean hasMachinePlaceholder = format.indexOf("%" + MACHINE_PLACEHOLDER) >= 0;
+        for (int index = 0; index < format.length(); index++) {
+            char current = format.charAt(index);
+            if (current != '%' || index + 1 >= format.length()) {
+                literal.append(current);
+                continue;
+            }
+
+            char placeholder = format.charAt(index + 1);
+            if (!isPlaceholder(placeholder)) {
+                literal.append(current).append(placeholder);
+                index++;
+                continue;
+            }
+
+            Component component = parts.get(placeholder);
+            if (component == null &&
+                    placeholder == RECIPE_TYPE_ALWAYS_PLACEHOLDER &&
+                    !hasMachinePlaceholder) {
+                component = parts.machine();
+            }
+            if (component != null && !component.getString().isBlank()) {
+                appendLiteral(result, literal.toString(), appended);
+                literal.setLength(0);
+                result.append(component);
+                appended = true;
+            }
+            index++;
+        }
+
+        if (appended) {
+            appendTrailingLiteral(result, literal.toString());
+            return result;
+        }
+        if (!literal.toString().isBlank()) {
+            return Component.literal(literal.toString().strip());
+        }
+        return parts.machine().copy();
+    }
+
+    private static boolean isPlaceholder(char placeholder) {
+        return placeholder == MACHINE_PLACEHOLDER ||
+                placeholder == TIER_PLACEHOLDER ||
+                placeholder == SUFFIX_PLACEHOLDER ||
+                placeholder == RECIPE_TYPE_MULTI_PLACEHOLDER ||
+                placeholder == RECIPE_TYPE_ALWAYS_PLACEHOLDER;
+    }
+
+    private static void appendLiteral(MutableComponent result, String literal, boolean hasPreviousField) {
+        if (literal.isEmpty()) {
+            return;
+        }
+        if (literal.isBlank()) {
+            if (hasPreviousField && !result.getString().endsWith(" ")) {
+                result.append(" ");
+            }
+            return;
+        }
+        result.append(hasPreviousField ? literal : literal.stripLeading());
+    }
+
+    private static void appendTrailingLiteral(MutableComponent result, String literal) {
+        if (!literal.isBlank()) {
+            result.append(literal.stripTrailing());
+        }
+    }
+
+    private record MachineNameContext(MetaMachine displayMachine,
+                                      @Nullable IRecipeLogicMachine recipeMachine,
+                                      @Nullable GTRecipeType selectedRecipeType,
+                                      boolean showAllRecipeTypes,
+                                      List<Component> tooltip) {}
+
+    private record NameParts(Component machine,
+                            @Nullable Component tier,
+                            @Nullable Component suffix,
+                            @Nullable Component recipeType,
+                            boolean multipleRecipeTypes) {
+
+        private @Nullable Component get(char placeholder) {
+            return switch (placeholder) {
+                case MACHINE_PLACEHOLDER -> machine;
+                case TIER_PLACEHOLDER -> tier;
+                case SUFFIX_PLACEHOLDER -> suffix;
+                case RECIPE_TYPE_MULTI_PLACEHOLDER -> multipleRecipeTypes ? recipeType : null;
+                case RECIPE_TYPE_ALWAYS_PLACEHOLDER -> recipeType;
+                default -> null;
+            };
+        }
+
     }
 }

--- a/src/main/java/com/gtocore/integration/ae/hooks/IExtendedPatternContainer.java
+++ b/src/main/java/com/gtocore/integration/ae/hooks/IExtendedPatternContainer.java
@@ -1,6 +1,7 @@
 package com.gtocore.integration.ae.hooks;
 
 import com.gtocore.common.data.GTORecipeTypes;
+import com.gtocore.integration.ae.PatternContainerGroupHelper;
 
 import com.gtolib.api.blockentity.IDirectionCacheBlockEntity;
 
@@ -12,9 +13,12 @@ import com.gregtechceu.gtceu.api.recipe.GTRecipeType;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.Nameable;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
+import appeng.api.implementations.blockentities.PatternContainerGroup;
 import appeng.blockentity.crafting.MolecularAssemblerBlockEntity;
 import appeng.helpers.patternprovider.PatternContainer;
 
@@ -22,8 +26,6 @@ import com.glodblock.github.extendedae.common.tileentities.TileExMolecularAssemb
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public interface IExtendedPatternContainer extends PatternContainer {
 
@@ -37,19 +39,23 @@ public interface IExtendedPatternContainer extends PatternContainer {
         return null;
     }
 
-    default Set<GTRecipeType> getSupportedRecipeTypes() {
+    default boolean gto$supportsRecipeType(GTRecipeType targetRecipeType) {
         var recipeType = gto$getRecipeType();
         if (recipeType == null ||
                 recipeType == GTORecipeTypes.DUMMY_RECIPES ||
                 recipeType == GTORecipeTypes.HATCH_COMBINED) {
             var recipeTypes = gto$getRecipeTypes();
-            return recipeTypes != null ? recipeTypes.stream()
-                    .flatMap(rt -> rt.getSmallRecipeMap() != null ? Stream.of(rt, rt.getSmallRecipeMap()) : Stream.of(rt))
-                    .collect(Collectors.toSet()) : Collections.emptySet();
-        } else if (recipeType.getSmallRecipeMap() != null) {
-            return Set.of(recipeType, recipeType.getSmallRecipeMap());
+            if (recipeTypes == null) {
+                return false;
+            }
+            for (GTRecipeType type : recipeTypes) {
+                if (matchesRecipeType(type, targetRecipeType)) {
+                    return true;
+                }
+            }
+            return false;
         }
-        return Collections.singleton(recipeType);
+        return matchesRecipeType(recipeType, targetRecipeType);
     }
 
     default boolean gto$isCraftingContainer() {
@@ -68,6 +74,34 @@ public interface IExtendedPatternContainer extends PatternContainer {
 
     default boolean isOutOfService() {
         return getGrid() == null;
+    }
+
+    default Component gto$getTerminalGroupSearchName() {
+        if (this instanceof Nameable nameable && nameable.hasCustomName()) {
+            String customName = nameable.getCustomName().getString();
+            if (!customName.startsWith("+")) {
+                return nameable.getCustomName();
+            }
+        }
+        if (this instanceof IPPPC self) {
+            var level = self.gto$getLevel();
+            var pos = self.gto$getBlockPos();
+            var extraSuffix = IExtendedPatternContainer.gto$getExtraSuffix(this);
+            for (var direction : self.gto$getPushDirection()) {
+                var adjacentPos = pos.relative(direction);
+                var searchName = PatternContainerGroupHelper.getSearchName(level, adjacentPos, extraSuffix);
+                if (searchName != null) {
+                    return searchName;
+                }
+                var fallbackGroup = PatternContainerGroup.fromMachine(level, adjacentPos, direction.getOpposite());
+                if (fallbackGroup != null) {
+                    return extraSuffix.isEmpty() ?
+                            fallbackGroup.name() :
+                            fallbackGroup.name().copy().append(" ").append(extraSuffix);
+                }
+            }
+        }
+        return getTerminalGroup().name();
     }
 
     interface IPPPC extends IExtendedPatternContainer {
@@ -92,6 +126,23 @@ public interface IExtendedPatternContainer extends PatternContainer {
             }
         }
         return null;
+    }
+
+    static String gto$getExtraSuffix(PatternContainer container) {
+        if (container instanceof Nameable nameable && nameable.hasCustomName()) {
+            String customName = nameable.getCustomName().getString();
+            if (customName.startsWith("+")) {
+                return customName.substring(1).strip();
+            }
+        }
+        return "";
+    }
+
+    static boolean matchesRecipeType(@Nullable GTRecipeType recipeType, GTRecipeType targetRecipeType) {
+        if (recipeType == null) {
+            return false;
+        }
+        return recipeType == targetRecipeType || recipeType.getSmallRecipeMap() == targetRecipeType;
     }
 
     static boolean gto$isCraftingContainer(IPPPC self) {
@@ -119,11 +170,15 @@ public interface IExtendedPatternContainer extends PatternContainer {
     @Nullable
     static List<GTRecipeType> gto$getRecipeTypes(IPPPC self) {
         var adjBe = IExtendedPatternContainer.getPushBlockEntity(self);
-        if (adjBe instanceof IMultiPart partMachine) {
+        if (!(adjBe instanceof MetaMachineBlockEntity mmbe)) {
+            return null;
+        }
+        MetaMachine mm = mmbe.getMetaMachine();
+        if (mm instanceof IMultiPart partMachine) {
             return partMachine.getController() instanceof IRecipeLogicMachine rlm ? Arrays.asList(rlm.getAvailableRecipeTypes()) : null;
         }
 
-        if (adjBe instanceof IRecipeLogicMachine rlm) {
+        if (mm instanceof IRecipeLogicMachine rlm) {
             return Arrays.asList(rlm.getAvailableRecipeTypes());
         }
 

--- a/src/main/java/com/gtocore/mixin/ae2/crafting/PatternContainerGroupMixin.java
+++ b/src/main/java/com/gtocore/mixin/ae2/crafting/PatternContainerGroupMixin.java
@@ -1,78 +1,27 @@
 package com.gtocore.mixin.ae2.crafting;
 
-import com.gtocore.common.machine.multiblock.electric.processing.ProcessingPlantMachine;
-
-import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
-import com.gregtechceu.gtceu.api.item.MetaMachineItem;
-import com.gregtechceu.gtceu.api.machine.MetaMachine;
-import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
-import com.gregtechceu.gtceu.api.machine.multiblock.part.MultiblockPartMachine;
+import com.gtocore.integration.ae.PatternContainerGroupHelper;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.network.chat.Component;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
 import appeng.api.implementations.blockentities.PatternContainerGroup;
-import appeng.api.stacks.AEItemKey;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.List;
-
 @Mixin(value = PatternContainerGroup.class, remap = false)
 public class PatternContainerGroupMixin {
-
-    @Unique
-    private static Component gto$getMachineName(MetaMachine machine) {
-        var title = Component.translatable(machine.getDefinition().getDescriptionId());
-        if (machine instanceof ProcessingPlantMachine processingPlantMachine) {
-            ItemStack stack = processingPlantMachine.getMachineStorage().getStackInSlot(0);
-            if (stack.getItem() instanceof MetaMachineItem metaMachineItem) {
-                return title.copy()
-                        .append(" - ")
-                        .append(Component.translatable(metaMachineItem.getDefinition().getDescriptionId()));
-            }
-        }
-        return title;
-    }
 
     @Inject(method = "fromMachine", at = @At("HEAD"), cancellable = true)
     private static void gto$fromMachine(Level level, BlockPos pos, Direction side,
                                         CallbackInfoReturnable<PatternContainerGroup> cir) {
-        if (!(level.getBlockEntity(pos) instanceof MetaMachineBlockEntity blockEntity)) {
-            return;
+        PatternContainerGroup group = PatternContainerGroupHelper.fromMachine(level, pos, "");
+        if (group != null) {
+            cir.setReturnValue(group);
         }
-
-        MetaMachine machine = blockEntity.getMetaMachine();
-        if (machine == null) {
-            return;
-        }
-
-        if (machine instanceof MultiblockPartMachine partMachine && partMachine.isFormed()) {
-            IMultiController controller = partMachine.getControllers().stream().findFirst().orElse(null);
-            if (controller == null) {
-                return;
-            }
-
-            var controllerMachine = controller.self();
-            var controllerDefinition = controllerMachine.getDefinition();
-            cir.setReturnValue(new PatternContainerGroup(
-                    AEItemKey.of(controllerDefinition.asStack()),
-                    gto$getMachineName(controllerMachine),
-                    List.of(Component.translatable(machine.getDefinition().getDescriptionId()))));
-            return;
-        }
-
-        var definition = machine.getDefinition();
-        cir.setReturnValue(new PatternContainerGroup(
-                AEItemKey.of(definition.asStack()),
-                gto$getMachineName(machine),
-                List.of()));
     }
 }

--- a/src/main/java/com/gtocore/mixin/ae2/crafting/PatternProviderLogicMixin.java
+++ b/src/main/java/com/gtocore/mixin/ae2/crafting/PatternProviderLogicMixin.java
@@ -137,7 +137,9 @@ public abstract class PatternProviderLogicMixin implements IPatternProviderLogic
             var group = PatternContainerGroupHelper.fromMachine(level, adjacentPos, extraSuffix);
             if (group == null) {
                 var fallbackGroup = PatternContainerGroup.fromMachine(level, adjacentPos, side.getOpposite());
-                group = new PatternContainerGroup(fallbackGroup.icon(), fallbackGroup.name().copy().append(suffix), fallbackGroup.tooltip());
+                if (fallbackGroup != null) {
+                    group = new PatternContainerGroup(fallbackGroup.icon(), fallbackGroup.name().copy().append(suffix), fallbackGroup.tooltip());
+                }
             }
             if (group != null) {
                 groups.add(group);

--- a/src/main/java/com/gtocore/mixin/ae2/crafting/PatternProviderLogicMixin.java
+++ b/src/main/java/com/gtocore/mixin/ae2/crafting/PatternProviderLogicMixin.java
@@ -136,7 +136,8 @@ public abstract class PatternProviderLogicMixin implements IPatternProviderLogic
             var adjacentPos = blockEntity.getBlockPos().relative(side);
             var group = PatternContainerGroupHelper.fromMachine(level, adjacentPos, extraSuffix);
             if (group == null) {
-                group = PatternContainerGroup.fromMachine(level, adjacentPos, side.getOpposite());
+                var fallbackGroup = PatternContainerGroup.fromMachine(level, adjacentPos, side.getOpposite());
+                group = new PatternContainerGroup(fallbackGroup.icon(), fallbackGroup.name().copy().append(suffix), fallbackGroup.tooltip());
             }
             if (group != null) {
                 groups.add(group);

--- a/src/main/java/com/gtocore/mixin/ae2/crafting/PatternProviderLogicMixin.java
+++ b/src/main/java/com/gtocore/mixin/ae2/crafting/PatternProviderLogicMixin.java
@@ -1,5 +1,7 @@
 package com.gtocore.mixin.ae2.crafting;
 
+import com.gtocore.integration.ae.PatternContainerGroupHelper;
+
 import com.gtolib.api.ae2.*;
 import com.gtolib.api.ae2.machine.ICustomCraftingMachine;
 import com.gtolib.api.blockentity.IDirectionCacheBlockEntity;
@@ -121,7 +123,8 @@ public abstract class PatternProviderLogicMixin implements IPatternProviderLogic
             return;
         }
 
-        var suffix = Component.literal(customName.substring(1));
+        String extraSuffix = customName.substring(1).strip();
+        var suffix = extraSuffix.isEmpty() ? Component.empty() : Component.literal(" ").append(extraSuffix);
         var blockEntity = host.getBlockEntity();
         var level = blockEntity.getLevel();
         if (level == null) {
@@ -130,15 +133,18 @@ public abstract class PatternProviderLogicMixin implements IPatternProviderLogic
 
         var groups = new LinkedHashSet<PatternContainerGroup>();
         for (Direction side : getActiveSides()) {
-            var group = PatternContainerGroup.fromMachine(level, blockEntity.getBlockPos().relative(side), side.getOpposite());
+            var adjacentPos = blockEntity.getBlockPos().relative(side);
+            var group = PatternContainerGroupHelper.fromMachine(level, adjacentPos, extraSuffix);
+            if (group == null) {
+                group = PatternContainerGroup.fromMachine(level, adjacentPos, side.getOpposite());
+            }
             if (group != null) {
                 groups.add(group);
             }
         }
 
         if (groups.size() == 1) {
-            var group = groups.getFirst();
-            cir.setReturnValue(new PatternContainerGroup(group.icon(), group.name().copy().append(suffix), group.tooltip()));
+            cir.setReturnValue(groups.getFirst());
             return;
         }
 

--- a/src/main/java/com/gtocore/mixin/ae2/eae/GuiExPatternTerminalGroupHeaderAccessor.java
+++ b/src/main/java/com/gtocore/mixin/ae2/eae/GuiExPatternTerminalGroupHeaderAccessor.java
@@ -1,0 +1,13 @@
+package com.gtocore.mixin.ae2.eae;
+
+import appeng.api.implementations.blockentities.PatternContainerGroup;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(targets = "com.glodblock.github.extendedae.client.gui.GuiExPatternTerminal$GroupHeaderRow", remap = false)
+public interface GuiExPatternTerminalGroupHeaderAccessor {
+
+    @Accessor("group")
+    PatternContainerGroup gto$getGroup();
+}

--- a/src/main/java/com/gtocore/mixin/ae2/eae/GuiExPatternTerminalMixin.java
+++ b/src/main/java/com/gtocore/mixin/ae2/eae/GuiExPatternTerminalMixin.java
@@ -4,9 +4,16 @@ import com.gtolib.api.ae2.gui.hooks.IExtendedGuiEx;
 import com.gtolib.api.ae2.me2in1.Me2in1Menu;
 import com.gtolib.api.ae2.me2in1.Me2in1Screen;
 
+import net.minecraft.Util;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.core.BlockPos;
+import net.minecraft.locale.Language;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.FormattedText;
+import net.minecraft.util.FormattedCharSequence;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.ItemStack;
 
@@ -39,6 +46,16 @@ public abstract class GuiExPatternTerminalMixin<T extends ContainerExPatternTerm
 
     @Unique
     private static final int gto$COLUMNS = 9;
+    @Unique
+    private static final int gto$TEXT_WIDTH = 145;
+    @Unique
+    private static final int gto$TEXT_SCROLL_PAUSE_MS = 500;
+    @Unique
+    private static final int gto$TEXT_SCROLL_PIXELS_PER_SECOND = 30;
+    @Unique
+    private PatternContainerGroup gto$scrollingGroup;
+    @Unique
+    private long gto$scrollingGroupHoverStart;
 
     @Shadow(remap = false)
     @Final
@@ -129,6 +146,80 @@ public abstract class GuiExPatternTerminalMixin<T extends ContainerExPatternTerm
         if (this.getMenu() instanceof Me2in1Menu) {
             scrollbar.setVisible(false);
         }
+    }
+
+    @Redirect(
+              method = "drawFG",
+              at = @At(
+                       value = "INVOKE",
+                       target = "Lnet/minecraft/client/gui/GuiGraphics;drawString(Lnet/minecraft/client/gui/Font;Lnet/minecraft/util/FormattedCharSequence;IIIZ)I"),
+              remap = false)
+    private int gto$drawScrollingGroupName(GuiGraphics guiGraphics, Font font, FormattedCharSequence originalText,
+                                           int x, int y, int color, boolean shadow) {
+        int visibleRow = (y - 57) / ROW_HEIGHT;
+        int rowIndex = scrollbar.getCurrentScroll() + visibleRow;
+        if (visibleRow < 0 || rowIndex < 0 || rowIndex >= rows.size() ||
+                !(rows.get(rowIndex) instanceof GuiExPatternTerminalGroupHeaderAccessor header)) {
+            return guiGraphics.drawString(font, originalText, x, y, color, shadow);
+        }
+
+        PatternContainerGroup group = header.gto$getGroup();
+        int groupCount = byGroup.get(group).size();
+        FormattedText displayName = groupCount > 1 ?
+                Component.empty().append(group.name()).append(" (" + groupCount + ')') : group.name();
+        int fullTextWidth = font.width(displayName);
+        if (fullTextWidth <= gto$TEXT_WIDTH || !gto$isGroupRowHovered(visibleRow)) {
+            if (group.equals(gto$scrollingGroup)) {
+                gto$scrollingGroup = null;
+            }
+            return guiGraphics.drawString(font,
+                    Language.getInstance().getVisualOrder(font.substrByWidth(displayName, gto$TEXT_WIDTH)),
+                    x, y, color, shadow);
+        }
+
+        if (!group.equals(gto$scrollingGroup)) {
+            gto$scrollingGroup = group;
+            gto$scrollingGroupHoverStart = Util.getMillis();
+        }
+        int scrollOffset = gto$getTextScrollOffset(fullTextWidth - gto$TEXT_WIDTH);
+        guiGraphics.enableScissor(leftPos + x, topPos + y,
+                leftPos + x + gto$TEXT_WIDTH, topPos + y + font.lineHeight);
+        int result = guiGraphics.drawString(font, Language.getInstance().getVisualOrder(displayName),
+                x - scrollOffset, y, color, shadow);
+        guiGraphics.disableScissor();
+        return result;
+    }
+
+    @Unique
+    private boolean gto$isGroupRowHovered(int visibleRow) {
+        Minecraft minecraft = Minecraft.getInstance();
+        double mouseX = minecraft.mouseHandler.xpos() * minecraft.getWindow().getGuiScaledWidth() /
+                minecraft.getWindow().getScreenWidth();
+        double mouseY = minecraft.mouseHandler.ypos() * minecraft.getWindow().getGuiScaledHeight() /
+                minecraft.getWindow().getScreenHeight();
+        return mouseX >= leftPos + 22 && mouseX < leftPos + 22 + gto$COLUMNS * ROW_HEIGHT &&
+                mouseY >= topPos + 51 + visibleRow * ROW_HEIGHT &&
+                mouseY < topPos + 51 + (visibleRow + 1) * ROW_HEIGHT;
+    }
+
+    @Unique
+    private int gto$getTextScrollOffset(int maxOffset) {
+        long travelTime = Math.max(1, maxOffset * 1000L / gto$TEXT_SCROLL_PIXELS_PER_SECOND);
+        long cycleTime = gto$TEXT_SCROLL_PAUSE_MS * 2L + travelTime * 2L;
+        long elapsed = (Util.getMillis() - gto$scrollingGroupHoverStart) % cycleTime;
+        if (elapsed < gto$TEXT_SCROLL_PAUSE_MS) {
+            return 0;
+        }
+        elapsed -= gto$TEXT_SCROLL_PAUSE_MS;
+        if (elapsed < travelTime) {
+            return (int) (maxOffset * elapsed / travelTime);
+        }
+        elapsed -= travelTime;
+        if (elapsed < gto$TEXT_SCROLL_PAUSE_MS) {
+            return maxOffset;
+        }
+        elapsed -= gto$TEXT_SCROLL_PAUSE_MS;
+        return maxOffset - (int) (maxOffset * elapsed / travelTime);
     }
 
     /**

--- a/src/main/java/com/gtocore/mixin/ae2/menu/PatternEncodingTermMenuMixin.java
+++ b/src/main/java/com/gtocore/mixin/ae2/menu/PatternEncodingTermMenuMixin.java
@@ -261,7 +261,7 @@ public abstract class PatternEncodingTermMenuMixin extends MEStorageMenu impleme
             return Comparator.comparing((IExtendedPatternContainer p) -> gto$canAddPattern(p, patternStack));
         }
         var c = Comparator.comparing((IExtendedPatternContainer p) -> gto$canAddPattern(p, patternStack))
-                .thenComparing((IExtendedPatternContainer p) -> p.getSupportedRecipeTypes().contains(recipeType));
+                .thenComparing((IExtendedPatternContainer p) -> p.gto$supportsRecipeType(recipeType));
         if (recipeLocName != null && !recipeLocName.isEmpty()) {
             c = c.thenComparing((IExtendedPatternContainer p) -> gto$matchesRecipeName(p, recipeLocName));
         }
@@ -270,9 +270,9 @@ public abstract class PatternEncodingTermMenuMixin extends MEStorageMenu impleme
 
     @Unique
     private static boolean gto$matchesRecipeName(IExtendedPatternContainer container, String recipeType) {
-        var name = container.getTerminalGroup().name().getString().toLowerCase(Locale.ROOT);
         var recipeNames = new LinkedHashSet<String>();
         recipeNames.add(recipeType.toLowerCase(Locale.ROOT));
+        var name = container.gto$getTerminalGroupSearchName().getString().toLowerCase(Locale.ROOT);
         for (var recipeName : recipeNames) {
             if (!recipeName.isEmpty() && name.contains(recipeName)) {
                 return true;

--- a/src/main/resources/gtocore.mixins.json
+++ b/src/main/resources/gtocore.mixins.json
@@ -11,6 +11,7 @@
     "adastra.PlanetsScreenMixin",
     "ae2.crafting.PendingCraftingJobsMixin",
     "ae2.eae.ExPATScreensMixin",
+    "ae2.eae.GuiExPatternTerminalGroupHeaderAccessor",
     "ae2.eae.GuiExPatternTerminalMixin",
     "ae2.eae.GuiPatternMixin",
     "ae2.eae.GuiTagExportBusMixin",


### PR DESCRIPTION
统一了样板供应器和样板总成系列在样板管理终端等位置的命名规则，现在的规则是

```
<机器名称> <最大配方等级> [额外后缀] [配方类型]
```

- 仅多配方机器显示配方类型，未指定类型时，以 / 分隔显示全部可执行类型
- 无可编程仓时，显示主机当前选择的配方类型
- `+` 开头的自定义名称作为额外后缀，其他自定义名称完整覆盖默认名称
- hover 显示实际连接的供应器或样板总成方块

<img width="539" height="256" alt="image" src="https://github.com/user-attachments/assets/eb9a79fe-cc51-4f6d-9220-d49f9de6a74b" />

<img width="450" height="474" alt="image" src="https://github.com/user-attachments/assets/4fbea338-710c-4bbb-b68c-cffdf2a3ced0" />

<img width="553" height="161" alt="image" src="https://github.com/user-attachments/assets/b13ad725-7376-48b9-affc-7535970a2823" />

为样板管理终端里显示太长了的情况加了滚动显示，这个 PR 里加了扩展样板管理终端的名称滚动，原版管理终端和 2in1 的分别改在 AE 和 GTOLib 里

<img width="946" height="288" alt="image" src="https://github.com/user-attachments/assets/9c970d76-a0e1-4dd5-a025-5eb8be738947" />




