### PR TITLE
fix: 修复并行发配合成样板时被可替换输入卡住的问题

### DIFF
--- a/src/main/java/com/gtocore/api/ae2/crafting/OptimizedCraftingCpuLogic.java
+++ b/src/main/java/com/gtocore/api/ae2/crafting/OptimizedCraftingCpuLogic.java
@@ -690,20 +690,23 @@ public class OptimizedCraftingCpuLogic extends CraftingCpuLogic {
         for (int x = 0; x < inputs.length; x++) {
             var list = inputHolder[x];
             var input = inputs[x];
-            long remainingMultiplier = input.getMultiplier();
-            for (var stack : input.getPossibleInputs()) {
-                var what = stack.what();
-                if (counter.contains(what)) {
-                    var amount = stack.amount();
-                    var extracted = sourceInv.extract(what, amount * remainingMultiplier, Actionable.MODULATE);
-                    if (extracted == 0) continue;
-                    list.add(what, extracted);
-                    remainingMultiplier -= (extracted / amount);
-                    if (remainingMultiplier == 0) break;
-                }
+            var possibleInputs = input.getPossibleInputs();
+            boolean combineSubstitutes = possibleInputs.length > 1 && hasSameTemplateAmount(possibleInputs);
+            long remaining = input.getMultiplier();
+            if (combineSubstitutes) {
+                remaining *= possibleInputs[0].amount();
+            }
+            for (var stack : possibleInputs) {
+                if (!counter.contains(stack.what())) continue;
+                long amount = combineSubstitutes ? 1 : stack.amount();
+                var extracted = sourceInv.extract(stack.what(), amount * remaining, Actionable.MODULATE);
+                if (extracted == 0) continue;
+                list.add(stack.what(), extracted);
+                remaining -= (extracted / amount);
+                if (remaining == 0) break;
             }
 
-            if (remainingMultiplier > 0) {
+            if (remaining > 0) {
                 found = false;
                 break;
             }
@@ -725,8 +728,11 @@ public class OptimizedCraftingCpuLogic extends CraftingCpuLogic {
         if (sourceInv.isEmpty()) return 0;
         for (IPatternDetails.IInput input : details.getInputs()) {
             long extracted = 0;
+            var seen = new ReferenceOpenHashSet<AEKey>();
             for (var stack : input.getPossibleInputs()) {
-                extracted += (sourceInv.getLong(stack.what()) / stack.amount());
+                if (seen.add(stack.what())) {
+                    extracted += sourceInv.getLong(stack.what()) / stack.amount();
+                }
             }
             maxParallel = Math.min(maxParallel, extracted / input.getMultiplier());
             if (maxParallel < 1) {
@@ -734,6 +740,14 @@ public class OptimizedCraftingCpuLogic extends CraftingCpuLogic {
             }
         }
         return maxParallel;
+    }
+
+    private static boolean hasSameTemplateAmount(GenericStack[] inputs) {
+        long amount = inputs[0].amount();
+        for (int i = 1; i < inputs.length; i++) {
+            if (inputs[i].amount() != amount) return false;
+        }
+        return true;
     }
 
     private static KeyCounter[] getInputHolder(IDetails details) {


### PR DESCRIPTION
超级分子装配室并行发配开启了“可替换”的合成样板时，如果同一个输入由多种合法替代品共同提供，CPU 可能无法发配样板。

以 `gtocore:me_wireless_connection_machine` 为例，每个产物需要：

- 4 个 EV 电路
- 4 个无线连接器

请求并行合成 5 个时，总共需要 20 个 EV 电路。网络中存在 16A + 4B 两种合法 EV 电路时，原料总数满足需求，但样板仍会卡住。

### 原因

并行样板会将每个可替换候选的模板数量乘以并行数。并行数为 5 时，EV 电路输入表现为：

```
possibleInputs:
A × 5
B × 5

multiplier:
4
```

原提取逻辑按每种候选的完整模板数量扣减：

```
16A / 5 = 3 份
4B / 5 = 0 份
```

因此只识别到 3 份输入，导致不进行发配

此外，合成样板的候选列表可能同时包含编码时选择的物品和配方 Ingredient 中的相同物品。原最大并行计算会重复统计同一个 AEKey。

### 修复方案

对于模板数量相同的可替换候选：

- 将输入需求转换为实际物品总数。
- 允许多种合法候选共同满足该数量。
- 不再要求每种候选分别提供完整的并行模板。

对于模板数量不同的输入，继续使用原有的按完整模板提取逻辑，避免改变其语义。最大并行计算同时对候选 AEKey 去重，防止同一物品被重复统计。