### PR TITLE
fix: 简易合成终端外部容器变动无法即时刷新

### DIFF
--- a/src/main/java/com/gtocore/integration/ae/SimpleCraftingTerminal.java
+++ b/src/main/java/com/gtocore/integration/ae/SimpleCraftingTerminal.java
@@ -164,8 +164,9 @@ public class SimpleCraftingTerminal extends AbstractTerminalPart
 
     @Override
     public TickingRequest getTickingRequest(IGridNode node) {
-        // 请求 AE2 网络每隔 10 tick 稳定调用一次
-        return new TickingRequest(10, 10, false, false);
+        // 每 10 tick 稳定 tick；canBeAlerted=true 让节点进入 alertable，
+        // 使 invalidateOnExternalStorageChange 的 alertDevice 不会抛 IllegalArgumentException（对齐 AE2 StorageBusPart）。
+        return new TickingRequest(10, 10, false, true);
     }
 
     @Override

--- a/src/main/java/com/gtocore/integration/ae/SimpleCraftingTerminal.java
+++ b/src/main/java/com/gtocore/integration/ae/SimpleCraftingTerminal.java
@@ -41,7 +41,9 @@ import appeng.items.parts.PartModels;
 import appeng.me.GridNode;
 import appeng.me.service.EnergyService;
 import appeng.me.service.StorageService;
+import appeng.me.service.TickManagerService;
 import appeng.me.storage.CompositeStorage;
+import appeng.me.storage.ITickingMonitor;
 import appeng.me.storage.MEInventoryHandler;
 import appeng.me.storage.NullInventory;
 import appeng.menu.me.items.CraftingTermMenu;
@@ -154,6 +156,9 @@ public class SimpleCraftingTerminal extends AbstractTerminalPart
             StorageService storageService = (StorageService) node.getGrid().getStorageService();
             storageService.addNode(node, null);
             energyService.addNode(node, null);
+            // IGridTickable 是事后 addService 补上的，须手动登记 TickManager，否则节点不会 tick、onTick 不执行。
+            TickManagerService tickManager = (TickManagerService) node.getGrid().getTickManager();
+            tickManager.addNode(node, null);
         }
     }
 
@@ -165,8 +170,9 @@ public class SimpleCraftingTerminal extends AbstractTerminalPart
 
     @Override
     public TickRateModulation tickingRequest(IGridNode node, int ticksSinceLastCall) {
-        if (this.handler.getDelegate() instanceof CompositeStorage compositeStorage) {
-            compositeStorage.onTick();
+        // 对齐 AE2 StorageBusPart：对任何 ITickingMonitor 调用 onTick 并回传其 tick 速率。
+        if (this.handler.getDelegate() instanceof ITickingMonitor monitor) {
+            return monitor.onTick();
         }
         return TickRateModulation.SAME;
     }
@@ -187,7 +193,8 @@ public class SimpleCraftingTerminal extends AbstractTerminalPart
                 return;
             }
             if (!foundExternalApi.isEmpty()) {
-                newInventory = foundExternalApi.size() > 1 ? new CompositeStorage(foundExternalApi) : foundExternalApi.reference2ReferenceEntrySet().fastIterator().next().getValue();
+                // 一律包成 CompositeStorage（含单一容器），使 delegate 可被 onTick 轮询刷新。
+                newInventory = new CompositeStorage(foundExternalApi);
             } else {
                 newInventory = NullInventory.of();
             }


### PR DESCRIPTION
简易合成终端放在容器上时，外部（非 AE2，如漏斗/其他自动化）写入相邻容器的物品不会即时刷新，必须手动在终端内移动一次物品才更新。

根因：SimpleCraftingTerminal 的 IGridTickable 服务是在节点加入网络后才用 addService 补上的，节点从未登记到 TickManager，导致 tickingRequest/onTick 永不执行，外部变动的轮询从未启动。

updateNode：补 tickManager.addNode，使节点真正参与 tick（与既有的 Storage/Energy 处理一致）
updateTarget：单一外部容器也包成 CompositeStorage，使 delegate 可被 onTick 轮询
tickingRequest：对任意 ITickingMonitor 调用 onTick 并回传其 tick 速率（对齐 AE2 StorageBusPart）
已于开发环境 runClient 实测：外部写入相邻箱子的物品约 0.5s 内自动刷新。