### PR TITLE
修复 Boss 召唤器只生成坐骑（蜘蛛）而 Boss 消失

### DIFF
--- a/src/main/java/com/gtocore/mixin/apoth/ApothBossMixin.java
+++ b/src/main/java/com/gtocore/mixin/apoth/ApothBossMixin.java
@@ -1,0 +1,42 @@
+package com.gtocore.mixin.apoth;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.level.ServerLevelAccessor;
+
+import dev.shadowsoffire.apotheosis.adventure.boss.ApothBoss;
+import dev.shadowsoffire.apotheosis.adventure.loot.LootRarity;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ApothBoss.class)
+public abstract class ApothBossMixin {
+
+    /**
+     * Apotheosis returns the mount instead of the boss when a boss has one, and only the mount gets
+     * positioned - the boss keeps its default (0, 0, 0) position and is lost when the caller spawns the
+     * pair, leaving a bare mount behind (e.g. the stray boss riding a spider). Drop the mount and hand
+     * back the boss itself.
+     */
+    @Inject(
+             method = "createBoss(Lnet/minecraft/world/level/ServerLevelAccessor;Lnet/minecraft/core/BlockPos;Lnet/minecraft/util/RandomSource;FLdev/shadowsoffire/apotheosis/adventure/loot/LootRarity;)Lnet/minecraft/world/entity/Mob;",
+             at = @At("RETURN"),
+             cancellable = true,
+             remap = false)
+    private void gtocore$dropBossMount(ServerLevelAccessor world, BlockPos pos, RandomSource random, float luck, @Nullable LootRarity rarity, CallbackInfoReturnable<Mob> cir) {
+        Mob result = cir.getReturnValue();
+        if (result == null || result.getPassengers().isEmpty()) return;
+        if (result.getPersistentData().getBoolean("apoth.boss")) return;
+        Entity rider = result.getFirstPassenger();
+        if (!(rider instanceof Mob boss) || !boss.getPersistentData().getBoolean("apoth.boss")) return;
+        boss.stopRiding();
+        result.discard();
+        boss.moveTo(pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5, random.nextFloat() * 360.0F, 0.0F);
+        cir.setReturnValue(boss);
+    }
+}

--- a/src/main/resources/gtocore.mixins.json
+++ b/src/main/resources/gtocore.mixins.json
@@ -121,6 +121,7 @@
     "ae2.wtlib.ItemWTMixin",
     "ae2.wtlib.WirelessTerminalMenuHostMixin",
     "apoth.AffixRegistry",
+    "apoth.ApothBossMixin",
     "appbot.AppliedBotanicsForgeMixin",
     "appbot.FluixPoolBlockEntityMixin",
     "arseng.ModdedTileMixin",


### PR DESCRIPTION
Apotheosis 的 ApothBoss#createBoss 在 boss 带坐骑时返回的是坐骑而非 boss，且只有坐骑被 moveTo 定位；
boss 本体保持默认的 (0, 0, 0) 位置，调用方 addFreshEntityWithPassengers 生成这一对时 boss 会丢失，
只剩坐骑留在世界里 —— 表现为 apotheosis:overworld/stray（流浪者骑蜘蛛，权重 75）只召唤出一只普通蜘蛛。只剩坐骑留在世界里 —— 表现为 apotheosis:overworld/stray（流浪者骑蜘蛛，权重 75）只召唤出一只普通蜘蛛。

本 PR 加 mixin 丢弃坐骑、直接返回 boss 本体并定位到目标坐标，一次修好三条召唤路径：
BOSS 召唤器多方块、Apotheosis 召唤器物品、Boss 生成方块。
