### PR TITLE
fix: 修复建筑小工具预览中的格雷科技机器显示为空壳

### DIFF
--- a/src/main/java/com/gtocore/mixin/buildinggadgets2/VBORendererMixin.java
+++ b/src/main/java/com/gtocore/mixin/buildinggadgets2/VBORendererMixin.java
@@ -1,0 +1,27 @@
+package com.gtocore.mixin.buildinggadgets2;
+
+import net.minecraft.client.renderer.RenderType;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+/**
+ * Building Gadgets draws the cutout part of a preview with its own render type, which alpha tests instead of
+ * blending, and draws everything else blended with depth writes. GregTech machines are registered on the
+ * cutoutMipped layer and their overlay quads sit exactly on top of the casing quads, so in the blended path the two
+ * fight over the depth buffer: the overlay wins, and since its centre is transparent the machine looks like a hollow
+ * pane. Draw cutoutMipped the way cutout is drawn.
+ */
+@Mixin(targets = "com.direwolf20.buildinggadgets2.client.renderer.VBORenderer", remap = false)
+public class VBORendererMixin {
+
+    @Redirect(method = "drawRender",
+              at = @At(value = "INVOKE", target = "Ljava/lang/Object;equals(Ljava/lang/Object;)Z"))
+    private static boolean gtocore$drawCutoutMippedLikeCutout(Object self, Object other) {
+        if (self instanceof RenderType renderType && RenderType.cutout().equals(other)) {
+            return renderType.equals(RenderType.cutout()) || renderType.equals(RenderType.cutoutMipped());
+        }
+        return self.equals(other);
+    }
+}

--- a/src/main/resources/gtocore.mixins.json
+++ b/src/main/resources/gtocore.mixins.json
@@ -27,6 +27,7 @@
     "ae2.screen.PatternAccessTermScreenMixin",
     "ae2.screen.PatternProviderScreenMixin",
     "ae2.search.RepoSearchMixin",
+    "buildinggadgets2.VBORendererMixin",
     "ftbxmodcompat.WrappedQuestCacheMixin",
     "ftbxmodcompat.WrappedQuestMixin",
     "gtm.renderer.TagPrefixItemRendererMixin",


### PR DESCRIPTION
## 问题

Building Gadgets 绘制预览时，只有 `cutout` 用它自己的渲染类型（`OurRenderTypes.RenderBlock`，做 alpha 裁切、不写深度），其余一律用原版 `translucent`（混色 + 写深度）。

格雷科技的机器注册在 `cutoutMipped` 层，而它的 overlay 面片与外壳（casing）面片**完全共面**。在混色 + 写深度这条路径下，两者争抢深度缓冲，overlay 胜出——而 overlay 中间是透明的，于是机器看起来就是一片空壳，只剩一个平面；视角变化时还会因为 z-fighting 而闪烁。

（在真实世界里没有这个问题：那边走的是 cutout 的 alpha 裁切。）

## 改动

新增 `mixin/buildinggadgets2/VBORendererMixin`：让 `cutoutMipped` 与 `cutout` 采用同样的绘制方式。

这实际上是 Building Gadgets 自身的缺陷，任何存在共面 overlay 面片的模组都会中招；这里先在 GTOCore 侧绕过。

## 依赖

需要配合 GregTech-Modern 的 `fix: 修复没有方块实体时机器不渲染`。**单独合并本 PR 没有效果**：没有那个修复，机器根本不会进入模型渲染路径，仍然是完全隐形。

## 测试

开发环境客户端（gtceu 打上上述补丁 + 本 mixin）实测：机器的粘贴预览显示为完整的立方体，外壳与正面贴图都正常。