### PR TITLE
修正错误的成分写法

### DIFF
--- a/src/main/java/com/gtocore/common/data/material/GTMaterialExtend.java
+++ b/src/main/java/com/gtocore/common/data/material/GTMaterialExtend.java
@@ -54,7 +54,7 @@ public final class GTMaterialExtend {
         Amprosium = Neutronium;
 
         RutheniumTriniumAmericiumNeutronate
-                .setFormula("RuTr2AmAp2O8");
+                .setFormula("RuKe2AmAp2O8");
 
         PlatinumMetal = material("platinum_metal", "铂金属")
                 .dust()


### PR DESCRIPTION
Trinium 是凯金，化学式（成分）为 Ke，而非 Tr（三钛）